### PR TITLE
Add API key authentication to OpenAI and MCP adapters

### DIFF
--- a/docs/how-to/authentication.md
+++ b/docs/how-to/authentication.md
@@ -1,0 +1,193 @@
+# How to Set Up Authentication
+
+This guide shows you how to secure your Xaibo server with API key authentication for both OpenAI and MCP adapters.
+
+## Quick Start
+
+The fastest way to add authentication:
+
+1. **Set environment variables:**
+   ```bash
+   export CUSTOM_OPENAI_API_KEY="your-openai-secret-key"
+   export MCP_API_KEY="your-mcp-secret-key"
+   ```
+
+2. **Start the server:**
+   ```bash
+   python -m xaibo.server.web --adapter xaibo.server.adapters.OpenAiApiAdapter --adapter xaibo.server.adapters.McpApiAdapter
+   ```
+
+3. **Test with curl:**
+   ```bash
+   curl -H "Authorization: Bearer your-openai-secret-key" http://localhost:8000/openai/models
+   ```
+
+## Step-by-Step Setup
+
+### 1. Choose Your Authentication Method
+
+**Option A: Environment Variables (Recommended)**
+```bash
+export CUSTOM_OPENAI_API_KEY="sk-your-secret-key-here"
+export MCP_API_KEY="mcp-your-secret-key-here"
+```
+
+**Option B: Command Line Arguments**
+```bash
+python -m xaibo.server.web \
+  --openai-api-key "sk-your-secret-key-here" \
+  --mcp-api-key "mcp-your-secret-key-here" \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter \
+  --adapter xaibo.server.adapters.McpApiAdapter
+```
+
+### 2. Start the Server with Adapters
+
+**For OpenAI API only:**
+```bash
+python -m xaibo.server.web --adapter xaibo.server.adapters.OpenAiApiAdapter
+```
+
+**For MCP only:**
+```bash
+python -m xaibo.server.web --adapter xaibo.server.adapters.McpApiAdapter
+```
+
+**For both adapters:**
+```bash
+python -m xaibo.server.web \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter \
+  --adapter xaibo.server.adapters.McpApiAdapter
+```
+
+### 3. Configure Your Agent Directory
+
+```bash
+python -m xaibo.server.web \
+  --agent-dir ./my-agents \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter
+```
+
+## Testing Authentication
+
+### Test OpenAI Adapter
+
+**List available models:**
+```bash
+curl -H "Authorization: Bearer your-openai-secret-key" \
+     http://localhost:8000/openai/models
+```
+
+**Send a chat completion:**
+```bash
+curl -X POST \
+  -H "Authorization: Bearer your-openai-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "your-agent-name",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }' \
+  http://localhost:8000/openai/chat/completions
+```
+
+### Test MCP Adapter
+
+**Initialize MCP connection:**
+```bash
+curl -X POST \
+  -H "Authorization: Bearer your-mcp-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {}
+    }
+  }' \
+  http://localhost:8000/mcp/
+```
+
+**List available tools:**
+```bash
+curl -X POST \
+  -H "Authorization: Bearer your-mcp-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tools/list",
+    "params": {}
+  }' \
+  http://localhost:8000/mcp/
+```
+
+## Common Issues
+
+### "Missing Authorization header"
+**Problem:** You forgot to include the Authorization header.
+
+**Solution:** Add the header to your request:
+```bash
+curl -H "Authorization: Bearer your-api-key" http://localhost:8000/openai/models
+```
+
+### "Invalid API key"
+**Problem:** The API key doesn't match what the server expects.
+
+**Solutions:**
+- Check your environment variables: `echo $CUSTOM_OPENAI_API_KEY`
+- Verify the key in your curl command matches exactly
+- Restart the server after changing environment variables
+
+### Server starts but authentication doesn't work
+**Problem:** API key not configured properly.
+
+**Solutions:**
+- Make sure environment variables are set before starting the server
+- Use command-line arguments instead: `--openai-api-key "your-key"`
+- Check server logs for authentication errors
+
+### MCP requests return HTTP 200 but with errors
+**Problem:** This is normal - MCP uses JSON-RPC protocol.
+
+**Solution:** Check the response body for error details:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "error": {
+    "code": -32001,
+    "message": "Invalid API key"
+  }
+}
+```
+
+## Security Notes
+
+- **Keep API keys secret** - never commit them to version control
+- **Use environment variables** for production deployments
+- **Use strong, random keys** - consider using `openssl rand -hex 32`
+- **Authentication is optional** - adapters work without API keys for development
+
+## No Authentication Setup
+
+To run without authentication (development only):
+
+```bash
+python -m xaibo.server.web \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter \
+  --adapter xaibo.server.adapters.McpApiAdapter
+```
+
+Then test without Authorization headers:
+```bash
+curl http://localhost:8000/openai/models
+```
+
+## Related Guides
+
+- [How to deploy with OpenAI-compatible API](deployment/openai-api.md) - Complete deployment guide with authentication examples
+- [How to deploy as an MCP server](deployment/mcp-server.md) - MCP deployment with authentication setup
+- [API Reference - Server Adapters](../reference/api/adapters.md) - Technical details about authentication implementation

--- a/docs/how-to/deployment/openai-api.md
+++ b/docs/how-to/deployment/openai-api.md
@@ -23,18 +23,28 @@ This includes FastAPI, Strawberry GraphQL, and other web server components.
 Use the built-in CLI for quick deployment:
 
 ```bash
-# Deploy all agents in the agents directory
+# Deploy all agents in the agents directory (no authentication)
 python -m xaibo.server.web \
   --agent-dir ./agents \
   --adapter xaibo.server.adapters.OpenAiApiAdapter \
   --host 0.0.0.0 \
   --port 8000
+
+# Deploy with API key authentication
+python -m xaibo.server.web \
+  --agent-dir ./agents \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --openai-api-key sk-your-secret-key-here
 ```
 
 
 ## Test your deployment
 
 Test the deployed API with curl:
+
+### Without Authentication
 
 ```bash
 # List available models (agents)
@@ -64,19 +74,82 @@ curl -X POST http://localhost:8000/openai/chat/completions \
   }'
 ```
 
+### With Authentication
+
+```bash
+# List available models (agents) with API key
+curl -X GET http://localhost:8000/openai/models \
+  -H "Authorization: Bearer sk-your-secret-key-here"
+
+# Send a chat completion request with API key
+curl -X POST http://localhost:8000/openai/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-your-secret-key-here" \
+  -d '{
+    "model": "your-agent-id",
+    "messages": [
+      {"role": "user", "content": "Hello, how are you?"}
+    ],
+    "temperature": 0.7,
+    "max_tokens": 1000
+  }'
+
+# Test streaming responses with API key
+curl -X POST http://localhost:8000/openai/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-your-secret-key-here" \
+  -d '{
+    "model": "your-agent-id",
+    "messages": [
+      {"role": "user", "content": "Tell me a story"}
+    ],
+    "stream": true
+  }'
+```
+
 ## Use with OpenAI client libraries
 
 Connect using official OpenAI client libraries:
 
 ### Python client
+
+#### Without Authentication
 ```python
 # client_test.py
 from openai import OpenAI
 
-# Point to your Xaibo deployment
+# Point to your Xaibo deployment (no authentication)
 client = OpenAI(
     base_url="http://localhost:8000/openai",
     api_key="not-needed"  # Xaibo doesn't require API key by default
+)
+
+# List available models (your agents)
+models = client.models.list()
+print("Available agents:")
+for model in models.data:
+    print(f"  - {model.id}")
+
+# Chat with an agent
+response = client.chat.completions.create(
+    model="your-agent-id",
+    messages=[
+        {"role": "user", "content": "What can you help me with?"}
+    ]
+)
+API_
+print(response.choices[0].message.content)
+```
+
+#### With Authentication
+```python
+# client_test_auth.py
+from openai import OpenAI
+
+# Point to your Xaibo deployment (with authentication)
+client = OpenAI(
+    base_url="http://localhost:8000/openai",
+    api_key="sk-your-secret-key-here"  # Use your configured API key
 )
 
 # List available models (your agents)
@@ -97,6 +170,8 @@ print(response.choices[0].message.content)
 ```
 
 ### Node.js client
+
+#### Without Authentication
 ```javascript
 // client_test.js
 import OpenAI from 'openai';
@@ -125,13 +200,106 @@ async function testAgent() {
 testAgent().catch(console.error);
 ```
 
+#### With Authentication
+```javascript
+// client_test_auth.js
+import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  baseURL: 'http://localhost:8000/openai',
+  apiKey: 'sk-your-secret-key-here'  // Use your configured API key
+});
+
+async function testAgent() {
+  // List available models
+  const models = await openai.models.list();
+  console.log('Available agents:', models.data.map(m => m.id));
+  
+  // Chat with an agent
+  const completion = await openai.chat.completions.create({
+    model: 'your-agent-id',
+    messages: [
+      { role: 'user', content: 'Hello from Node.js!' }
+    ]
+  });
+  
+  console.log(completion.choices[0].message.content);
+}
+
+testAgent().catch(console.error);
+```
+
+## API Key Configuration
+
+!!! tip "Detailed Authentication Setup"
+    For comprehensive authentication setup including troubleshooting and security best practices, see the [authentication guide](../authentication.md).
+
+### Environment Variables
+
+The recommended approach is to use environment variables for API key configuration:
+
+```bash
+# Set environment variable
+export CUSTOM_OPENAI_API_KEY="sk-your-secret-key-here"
+
+# Start server (API key automatically detected)
+python -m xaibo.server.web \
+  --agent-dir ./agents \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+### Command Line Arguments
+
+Alternatively, provide API keys via command line arguments:
+
+```bash
+# API key via command line (overrides environment variable)
+python -m xaibo.server.web \
+  --agent-dir ./agents \
+  --adapter xaibo.server.adapters.OpenAiApiAdapter \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --openai-api-key sk-your-secret-key-here
+```
+
+### Docker Deployment
+
+```dockerfile
+# Dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+
+# Use environment variable for API key
+ENV CUSTOM_OPENAI_API_KEY=""
+
+CMD ["python", "-m", "xaibo.server.web", \
+     "--agent-dir", "./agents", \
+     "--adapter", "xaibo.server.adapters.OpenAiApiAdapter", \
+     "--host", "0.0.0.0", \
+     "--port", "8000"]
+```
+
+```bash
+# Run with Docker
+docker run -e CUSTOM_OPENAI_API_KEY=sk-your-secret-key-here -p 8000:8000 your-xaibo-image
+```
+
 ## Best practices
 
 ### Security
 - Use HTTPS in production
-- Implement API key authentication if needed
+- Always use API key authentication in production environments
 - Set up proper CORS policies
 - Use environment variables for secrets
+- Rotate API keys regularly
+- Monitor API key usage for unusual patterns
 
 ### Performance
 - Use multiple workers for high load

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -6,6 +6,10 @@ How-to guides provide step-by-step instructions for solving specific problems wi
 
 - [How to install Xaibo with different dependency groups](installation.md) - Install Xaibo with only the dependencies you need
 
+## Security
+
+- [How to set up authentication](authentication.md) - Secure your Xaibo server with API key authentication for OpenAI and MCP adapters
+
 ## Tools Integration
 
 - [How to create and integrate Python tools](tools/python-tools.md) - Add custom Python functions as agent tools

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -24,3 +24,6 @@ This section provides comprehensive technical documentation for Xaibo's APIs, mo
 - **[Web Server API](api/server.md)** - Web server configuration and lifecycle
 - **[API Adapters](api/adapters.md)** - OpenAI and MCP adapter specifications
 - **[OpenAI Responses Adapter](api/openai-responses-adapter.md)** - Advanced OpenAI-compatible response management with conversation persistence
+
+### Troubleshooting
+- **[Troubleshooting Reference](troubleshooting.md)** - Systematic solutions for common issues including authentication, configuration, and integration problems

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -147,6 +147,9 @@ exchange:
 - `401 Unauthorized` responses
 - Missing API key errors
 
+!!! note "Server Authentication vs LLM Provider Authentication"
+    This section covers authentication with LLM providers (OpenAI, Anthropic, etc.). For securing your Xaibo server with API keys, see the [authentication guide](../how-to/authentication.md).
+
 **Resolution:**
 
 1. Create `.env` file in project root:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
     - how-to/index.md
     - Getting Started:
       - Installation: how-to/installation.md
+      - Authentication: how-to/authentication.md
     - Tools:
       - Python Tools: how-to/tools/python-tools.md
       - MCP Tools: how-to/tools/mcp-tools.md
@@ -130,6 +131,7 @@ nav:
     - API Reference:
       - Web Server: reference/api/server.md
       - API Adapters: reference/api/adapters.md
+      - OpenAI Responses Adapter: reference/api/openai-responses-adapter.md
     - Troubleshooting: reference/troubleshooting.md
   - Explanation:
     - explanation/index.md

--- a/tests/webserver/test_integration_api_keys.py
+++ b/tests/webserver/test_integration_api_keys.py
@@ -1,0 +1,422 @@
+import pytest
+import json
+import os
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from xaibo import Xaibo, AgentConfig, ModuleConfig
+from xaibo.server.adapters.openai import OpenAiApiAdapter
+from xaibo.server.adapters.mcp import McpApiAdapter
+from xaibo.core.protocols import TextMessageHandlerProtocol, ResponseProtocol
+
+
+class SimpleEcho(TextMessageHandlerProtocol):
+    """Simple echo module for integration testing"""
+    
+    @classmethod
+    def provides(cls):
+        return [TextMessageHandlerProtocol]
+    
+    def __init__(self, response: ResponseProtocol, config: dict | None = None):
+        self.config = config or {}
+        self.prefix = self.config.get("prefix", "")
+        self.response = response
+        
+    async def handle_text(self, text: str) -> None:
+        await self.response.respond_text(f"{self.prefix}{text}")
+
+
+@pytest.fixture
+def xaibo_with_agents():
+    """Create a Xaibo instance with test agents"""
+    xaibo = Xaibo()
+    
+    # Register a simple echo agent
+    echo_config = AgentConfig(
+        id="integration-echo",
+        modules=[
+            ModuleConfig(
+                module=SimpleEcho,
+                id="echo",
+                config={
+                    "prefix": "Integration: "
+                }
+            )
+        ]
+    )
+    xaibo.register_agent(echo_config)
+    
+    return xaibo
+
+
+@pytest.fixture
+def app_with_both_adapters_and_keys(xaibo_with_agents):
+    """Create a FastAPI app with both OpenAI and MCP adapters with API keys"""
+    app = FastAPI()
+    
+    # Add OpenAI adapter with API key
+    openai_adapter = OpenAiApiAdapter(xaibo_with_agents, api_key="integration-openai-key")
+    openai_adapter.adapt(app)
+    
+    # Add MCP adapter with API key
+    mcp_adapter = McpApiAdapter(xaibo_with_agents, api_key="integration-mcp-key")
+    mcp_adapter.adapt(app)
+    
+    return app
+
+
+@pytest.fixture
+def app_with_mixed_auth(xaibo_with_agents):
+    """Create a FastAPI app with one adapter with API key and one without"""
+    app = FastAPI()
+    
+    # Add OpenAI adapter with API key
+    openai_adapter = OpenAiApiAdapter(xaibo_with_agents, api_key="mixed-openai-key")
+    openai_adapter.adapt(app)
+    
+    # Add MCP adapter without API key
+    mcp_adapter = McpApiAdapter(xaibo_with_agents, api_key=None)
+    mcp_adapter.adapt(app)
+    
+    return app
+
+
+@pytest.fixture
+def client_with_both_adapters(app_with_both_adapters_and_keys):
+    """Create a test client for the app with both adapters"""
+    return TestClient(app_with_both_adapters_and_keys)
+
+
+@pytest.fixture
+def client_with_mixed_auth(app_with_mixed_auth):
+    """Create a test client for the app with mixed authentication"""
+    return TestClient(app_with_mixed_auth)
+
+
+def test_integration_openai_full_cycle_with_auth(client_with_both_adapters):
+    """Test full OpenAI request/response cycle with authentication"""
+    headers = {"Authorization": "Bearer integration-openai-key"}
+    
+    # Test models endpoint
+    response = client_with_both_adapters.get("/openai/models", headers=headers)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["object"] == "list"
+    model_ids = [model["id"] for model in data["data"]]
+    assert "integration-echo" in model_ids
+    
+    # Test chat completion
+    request_data = {
+        "model": "integration-echo",
+        "messages": [
+            {"role": "user", "content": "Hello integration test"}
+        ]
+    }
+    
+    response = client_with_both_adapters.post("/openai/chat/completions", json=request_data, headers=headers)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["object"] == "chat.completion"
+    assert data["choices"][0]["message"]["content"] == "Integration: Hello integration test"
+    
+    # Test streaming chat completion
+    request_data["stream"] = True
+    
+    with client_with_both_adapters.stream(
+        "POST",
+        "/openai/chat/completions",
+        json=request_data,
+        headers=headers
+    ) as response:
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "text/event-stream; charset=utf-8"
+        
+        # Read the streaming response
+        complete_content = ""
+        for line in response.iter_lines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                data = json.loads(line[6:])  # Remove "data: " prefix
+                if "choices" in data and data["choices"][0]["delta"].get("content"):
+                    content = data["choices"][0]["delta"]["content"]
+                    complete_content += content
+    
+    assert "Integration: Hello integration test" == complete_content
+
+
+def test_integration_mcp_full_cycle_with_auth(client_with_both_adapters):
+    """Test full MCP request/response cycle with authentication"""
+    headers = {"Authorization": "Bearer integration-mcp-key"}
+    
+    # Test initialize
+    init_request = {
+        "jsonrpc": "2.0",
+        "id": "integration-init",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "integration-test-client",
+                "version": "1.0.0"
+            }
+        }
+    }
+    
+    response = client_with_both_adapters.post("/mcp/", json=init_request, headers=headers)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert data["id"] == "integration-init"
+    assert "result" in data
+    assert data["result"]["serverInfo"]["name"] == "xaibo-mcp-server"
+    
+    # Test tools/list
+    list_request = {
+        "jsonrpc": "2.0",
+        "id": "integration-list",
+        "method": "tools/list",
+        "params": {}
+    }
+    
+    response = client_with_both_adapters.post("/mcp/", json=list_request, headers=headers)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "result" in data
+    tools = data["result"]["tools"]
+    tool_names = [tool["name"] for tool in tools]
+    assert "integration-echo" in tool_names
+    
+    # Test tools/call
+    call_request = {
+        "jsonrpc": "2.0",
+        "id": "integration-call",
+        "method": "tools/call",
+        "params": {
+            "name": "integration-echo",
+            "arguments": {
+                "message": "Hello MCP integration test"
+            }
+        }
+    }
+    
+    response = client_with_both_adapters.post("/mcp/", json=call_request, headers=headers)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "result" in data
+    assert data["result"]["content"][0]["text"] == "Integration: Hello MCP integration test"
+
+
+def test_integration_mixed_auth_scenario(client_with_mixed_auth):
+    """Test mixed authentication scenario - one adapter with auth, one without"""
+    # Test OpenAI with authentication (should require auth)
+    openai_headers = {"Authorization": "Bearer mixed-openai-key"}
+    
+    response = client_with_mixed_auth.get("/openai/models", headers=openai_headers)
+    assert response.status_code == 200
+    
+    # Test OpenAI without authentication (should fail)
+    response = client_with_mixed_auth.get("/openai/models")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing Authorization header"
+    
+    # Test MCP without authentication (should work - no auth required)
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "id": "mixed-test",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {}
+        }
+    }
+    
+    response = client_with_mixed_auth.post("/mcp/", json=mcp_request)
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "result" in data
+    
+    # Test MCP with authentication (should also work - auth is optional)
+    mcp_headers = {"Authorization": "Bearer any-key"}  # Any key should work since no auth required
+    response = client_with_mixed_auth.post("/mcp/", json=mcp_request, headers=mcp_headers)
+    assert response.status_code == 200
+
+
+def test_integration_error_handling_with_auth(client_with_both_adapters):
+    """Test error handling with authentication"""
+    # Test OpenAI with wrong API key
+    wrong_headers = {"Authorization": "Bearer wrong-key"}
+    
+    response = client_with_both_adapters.get("/openai/models", headers=wrong_headers)
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+    
+    # Test MCP with wrong API key
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "id": "error-test",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {}
+        }
+    }
+    
+    response = client_with_both_adapters.post("/mcp/", json=mcp_request, headers=wrong_headers)
+    assert response.status_code == 200  # MCP uses 200 for JSON-RPC errors
+    
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "error" in data
+    assert data["error"]["code"] == -32001
+    assert "Invalid API key" in data["error"]["message"]
+
+
+def test_integration_proper_http_status_codes(client_with_both_adapters):
+    """Test that proper HTTP status codes are returned"""
+    # OpenAI authentication errors should return HTTP 401
+    response = client_with_both_adapters.get("/openai/models")
+    assert response.status_code == 401
+    
+    response = client_with_both_adapters.get("/openai/models", headers={"Authorization": "Bearer wrong-key"})
+    assert response.status_code == 401
+    
+    # OpenAI successful requests should return HTTP 200
+    response = client_with_both_adapters.get("/openai/models", headers={"Authorization": "Bearer integration-openai-key"})
+    assert response.status_code == 200
+    
+    # MCP always returns HTTP 200 (JSON-RPC protocol)
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "id": "status-test",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {}
+        }
+    }
+    
+    # MCP with wrong auth
+    response = client_with_both_adapters.post("/mcp/", json=mcp_request, headers={"Authorization": "Bearer wrong-key"})
+    assert response.status_code == 200  # Still 200, but with JSON-RPC error
+    
+    # MCP with correct auth
+    response = client_with_both_adapters.post("/mcp/", json=mcp_request, headers={"Authorization": "Bearer integration-mcp-key"})
+    assert response.status_code == 200
+
+
+def test_integration_environment_variable_fallback(xaibo_with_agents, monkeypatch):
+    """Test environment variable fallback in integration scenario"""
+    # Set environment variables
+    monkeypatch.setenv("OPENAI_API_KEY", "env-openai-integration")
+    monkeypatch.setenv("MCP_API_KEY", "env-mcp-integration")
+    
+    app = FastAPI()
+    
+    # Create adapters without explicit API keys (should use env vars)
+    openai_adapter = OpenAiApiAdapter(xaibo_with_agents)
+    openai_adapter.adapt(app)
+    
+    mcp_adapter = McpApiAdapter(xaibo_with_agents)
+    mcp_adapter.adapt(app)
+    
+    client = TestClient(app)
+    
+    # Test OpenAI with env var key
+    response = client.get("/openai/models", headers={"Authorization": "Bearer env-openai-integration"})
+    assert response.status_code == 200
+    
+    # Test MCP with env var key
+    mcp_request = {
+        "jsonrpc": "2.0",
+        "id": "env-test",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {}
+        }
+    }
+    
+    response = client.post("/mcp/", json=mcp_request, headers={"Authorization": "Bearer env-mcp-integration"})
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert "result" in data
+
+
+def test_integration_concurrent_requests_with_auth(client_with_both_adapters):
+    """Test concurrent requests with authentication"""
+    import concurrent.futures
+    import threading
+    
+    def make_openai_request():
+        headers = {"Authorization": "Bearer integration-openai-key"}
+        response = client_with_both_adapters.get("/openai/models", headers=headers)
+        return response.status_code == 200
+    
+    def make_mcp_request():
+        headers = {"Authorization": "Bearer integration-mcp-key"}
+        request_data = {
+            "jsonrpc": "2.0",
+            "id": f"concurrent-{threading.current_thread().ident}",
+            "method": "tools/list",
+            "params": {}
+        }
+        response = client_with_both_adapters.post("/mcp/", json=request_data, headers=headers)
+        return response.status_code == 200
+    
+    # Run concurrent requests
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        openai_futures = [executor.submit(make_openai_request) for _ in range(5)]
+        mcp_futures = [executor.submit(make_mcp_request) for _ in range(5)]
+        
+        # Wait for all requests to complete
+        openai_results = [future.result() for future in openai_futures]
+        mcp_results = [future.result() for future in mcp_futures]
+    
+    # All requests should succeed
+    assert all(openai_results), "Some OpenAI requests failed"
+    assert all(mcp_results), "Some MCP requests failed"
+
+
+def test_integration_malformed_auth_headers(client_with_both_adapters):
+    """Test various malformed authentication headers"""
+    malformed_headers = [
+        {"Authorization": "Basic dGVzdDp0ZXN0"},  # Wrong auth type
+        {"Authorization": "Bearertest-key"},      # No space after Bearer
+        {"Authorization": "Bearer "},             # Empty key
+        {"Authorization": ""},                    # Empty header
+        {"Auth": "Bearer test-key"},              # Wrong header name
+    ]
+    
+    for headers in malformed_headers:
+        # Test OpenAI
+        response = client_with_both_adapters.get("/openai/models", headers=headers)
+        assert response.status_code == 401, f"OpenAI should reject malformed header: {headers}"
+        
+        # Test MCP
+        mcp_request = {
+            "jsonrpc": "2.0",
+            "id": "malformed-test",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {}
+            }
+        }
+        
+        response = client_with_both_adapters.post("/mcp/", json=mcp_request, headers=headers)
+        assert response.status_code == 200, "MCP should always return 200"
+        
+        data = response.json()
+        assert "error" in data, f"MCP should return error for malformed header: {headers}"
+        assert data["error"]["code"] == -32001, "MCP should return auth error code"

--- a/tests/webserver/test_web_server.py
+++ b/tests/webserver/test_web_server.py
@@ -1,0 +1,384 @@
+import pytest
+import os
+from unittest.mock import Mock, patch, MagicMock
+from fastapi import FastAPI
+
+from xaibo import Xaibo
+from xaibo.server.web import XaiboWebServer, get_class_by_path
+from xaibo.server.adapters.openai import OpenAiApiAdapter
+from xaibo.server.adapters.mcp import McpApiAdapter
+
+
+class MockAdapter:
+    """Mock adapter for testing"""
+    def __init__(self, xaibo, **kwargs):
+        self.xaibo = xaibo
+        self.kwargs = kwargs
+        
+    def adapt(self, app):
+        pass
+
+
+class MockOpenAiAdapter:
+    """Mock OpenAI adapter for testing"""
+    def __init__(self, xaibo, api_key=None, **kwargs):
+        self.xaibo = xaibo
+        self.api_key = api_key
+        self.kwargs = kwargs
+        
+    def adapt(self, app):
+        pass
+
+
+class MockMcpAdapter:
+    """Mock MCP adapter for testing"""
+    def __init__(self, xaibo, api_key=None, **kwargs):
+        self.xaibo = xaibo
+        self.api_key = api_key
+        self.kwargs = kwargs
+        
+    def adapt(self, app):
+        pass
+
+
+@pytest.fixture
+def xaibo_instance():
+    """Create a test Xaibo instance"""
+    return Xaibo()
+
+
+@pytest.fixture
+def temp_agent_dir(tmp_path):
+    """Create a temporary agent directory"""
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
+    return str(agent_dir)
+
+
+def test_get_class_by_path():
+    """Test the get_class_by_path utility function"""
+    # Test with a real class
+    cls = get_class_by_path("xaibo.server.adapters.openai.OpenAiApiAdapter")
+    assert cls == OpenAiApiAdapter
+    
+    cls = get_class_by_path("xaibo.server.adapters.mcp.McpApiAdapter")
+    assert cls == McpApiAdapter
+
+
+def test_web_server_initialization_no_api_keys(xaibo_instance, temp_agent_dir):
+    """Test web server initialization without API keys"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_get_class.return_value = MockAdapter
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=["test.adapter.MockAdapter"],
+            agent_dir=temp_agent_dir,
+            host="127.0.0.1",
+            port=8000,
+            debug=False,
+            openai_api_key=None,
+            mcp_api_key=None
+        )
+        
+        assert server.xaibo == xaibo_instance
+        assert server.host == "127.0.0.1"
+        assert server.port == 8000
+        assert server.openai_api_key is None
+        assert server.mcp_api_key is None
+        assert isinstance(server.app, FastAPI)
+
+
+def test_web_server_initialization_with_api_keys(xaibo_instance, temp_agent_dir):
+    """Test web server initialization with API keys"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_get_class.return_value = MockAdapter
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=["test.adapter.MockAdapter"],
+            agent_dir=temp_agent_dir,
+            host="0.0.0.0",
+            port=9000,
+            debug=False,
+            openai_api_key="test-openai-key",
+            mcp_api_key="test-mcp-key"
+        )
+        
+        assert server.openai_api_key == "test-openai-key"
+        assert server.mcp_api_key == "test-mcp-key"
+        assert server.host == "0.0.0.0"
+        assert server.port == 9000
+
+
+def test_web_server_openai_adapter_instantiation(xaibo_instance, temp_agent_dir):
+    """Test that OpenAI adapter receives the correct API key"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_adapter_class = Mock()
+        mock_adapter_instance = Mock()
+        mock_adapter_class.return_value = mock_adapter_instance
+        mock_adapter_class.__name__ = "OpenAiApiAdapter"
+        mock_get_class.return_value = mock_adapter_class
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=["xaibo.server.adapters.openai.OpenAiApiAdapter"],
+            agent_dir=temp_agent_dir,
+            openai_api_key="test-openai-key-123"
+        )
+        
+        # Verify the adapter was instantiated with the correct API key
+        mock_adapter_class.assert_called_once_with(xaibo_instance, api_key="test-openai-key-123")
+        mock_adapter_instance.adapt.assert_called_once_with(server.app)
+
+
+def test_web_server_mcp_adapter_instantiation(xaibo_instance, temp_agent_dir):
+    """Test that MCP adapter receives the correct API key"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_adapter_class = Mock()
+        mock_adapter_instance = Mock()
+        mock_adapter_class.return_value = mock_adapter_instance
+        mock_adapter_class.__name__ = "McpApiAdapter"
+        mock_get_class.return_value = mock_adapter_class
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=["xaibo.server.adapters.mcp.McpApiAdapter"],
+            agent_dir=temp_agent_dir,
+            mcp_api_key="test-mcp-key-456"
+        )
+        
+        # Verify the adapter was instantiated with the correct API key
+        mock_adapter_class.assert_called_once_with(xaibo_instance, api_key="test-mcp-key-456")
+        mock_adapter_instance.adapt.assert_called_once_with(server.app)
+
+
+def test_web_server_other_adapter_instantiation(xaibo_instance, temp_agent_dir):
+    """Test that other adapters don't receive API keys"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_adapter_class = Mock()
+        mock_adapter_instance = Mock()
+        mock_adapter_class.return_value = mock_adapter_instance
+        mock_adapter_class.__name__ = "SomeOtherAdapter"
+        mock_get_class.return_value = mock_adapter_class
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=["some.other.SomeOtherAdapter"],
+            agent_dir=temp_agent_dir,
+            openai_api_key="test-openai-key",
+            mcp_api_key="test-mcp-key"
+        )
+        
+        # Verify the adapter was instantiated without API keys
+        mock_adapter_class.assert_called_once_with(xaibo_instance)
+        mock_adapter_instance.adapt.assert_called_once_with(server.app)
+
+
+def test_web_server_multiple_adapters_with_api_keys(xaibo_instance, temp_agent_dir):
+    """Test that multiple adapters receive their respective API keys"""
+    adapters_and_classes = [
+        ("xaibo.server.adapters.openai.OpenAiApiAdapter", "OpenAiApiAdapter"),
+        ("xaibo.server.adapters.mcp.McpApiAdapter", "McpApiAdapter"),
+        ("some.other.SomeOtherAdapter", "SomeOtherAdapter")
+    ]
+    
+    mock_classes = {}
+    mock_instances = {}
+    
+    def mock_get_class_side_effect(path):
+        for adapter_path, class_name in adapters_and_classes:
+            if path == adapter_path:
+                if class_name not in mock_classes:
+                    mock_class = Mock()
+                    mock_instance = Mock()
+                    mock_class.return_value = mock_instance
+                    mock_class.__name__ = class_name
+                    mock_classes[class_name] = mock_class
+                    mock_instances[class_name] = mock_instance
+                return mock_classes[class_name]
+        return Mock()
+    
+    with patch('xaibo.server.web.get_class_by_path', side_effect=mock_get_class_side_effect):
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=[path for path, _ in adapters_and_classes],
+            agent_dir=temp_agent_dir,
+            openai_api_key="test-openai-key",
+            mcp_api_key="test-mcp-key"
+        )
+        
+        # Verify OpenAI adapter got the OpenAI API key
+        mock_classes["OpenAiApiAdapter"].assert_called_once_with(xaibo_instance, api_key="test-openai-key")
+        
+        # Verify MCP adapter got the MCP API key
+        mock_classes["McpApiAdapter"].assert_called_once_with(xaibo_instance, api_key="test-mcp-key")
+        
+        # Verify other adapter didn't get any API key
+        mock_classes["SomeOtherAdapter"].assert_called_once_with(xaibo_instance)
+        
+        # Verify all adapters were adapted
+        for instance in mock_instances.values():
+            instance.adapt.assert_called_once_with(server.app)
+
+
+def test_web_server_backward_compatibility_no_api_keys(xaibo_instance, temp_agent_dir):
+    """Test backward compatibility when no API keys are provided"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_openai_class = Mock()
+        mock_openai_instance = Mock()
+        mock_openai_class.return_value = mock_openai_instance
+        mock_openai_class.__name__ = "OpenAiApiAdapter"
+        
+        mock_mcp_class = Mock()
+        mock_mcp_instance = Mock()
+        mock_mcp_class.return_value = mock_mcp_instance
+        mock_mcp_class.__name__ = "McpApiAdapter"
+        
+        def side_effect(path):
+            if "openai" in path.lower():
+                return mock_openai_class
+            elif "mcp" in path.lower():
+                return mock_mcp_class
+            return Mock()
+        
+        mock_get_class.side_effect = side_effect
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=[
+                "xaibo.server.adapters.openai.OpenAiApiAdapter",
+                "xaibo.server.adapters.mcp.McpApiAdapter"
+            ],
+            agent_dir=temp_agent_dir,
+            openai_api_key=None,
+            mcp_api_key=None
+        )
+        
+        # Verify adapters were instantiated with None API keys (backward compatibility)
+        mock_openai_class.assert_called_once_with(xaibo_instance, api_key=None)
+        mock_mcp_class.assert_called_once_with(xaibo_instance, api_key=None)
+
+
+def test_web_server_debug_mode_adds_ui_adapter(xaibo_instance, temp_agent_dir):
+    """Test that debug mode adds the UI adapter"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class, \
+         patch('xaibo.server.adapters.ui.UIDebugTraceEventListener') as mock_listener:
+        
+        mock_adapter_class = Mock()
+        mock_adapter_instance = Mock()
+        mock_adapter_class.return_value = mock_adapter_instance
+        mock_adapter_class.__name__ = "MockAdapter"
+        mock_get_class.return_value = mock_adapter_class
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=["test.MockAdapter"],
+            agent_dir=temp_agent_dir,
+            debug=True
+        )
+        
+        # Verify that the UI adapter was added to the adapters list
+        # The debug mode should add "xaibo.server.adapters.UiApiAdapter"
+        assert mock_get_class.call_count == 2  # Original adapter + UI adapter
+        
+        # Verify event listener was registered
+        mock_listener.assert_called_once()
+
+
+def test_command_line_argument_parsing():
+    """Test command line argument parsing for API keys"""
+    import argparse
+    
+    # Test that the argument parser accepts the API key arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent-dir", dest="agent_dir", default="./agents", action="store")
+    parser.add_argument("--adapter", dest="adapters", default=[], action="append")
+    parser.add_argument("--host", dest="host", default="127.0.0.1", action="store")
+    parser.add_argument("--port", dest="port", default=8000, type=int, action="store")
+    parser.add_argument("--debug-ui", dest="debug", default=False, type=bool, action="store")
+    parser.add_argument("--openai-api-key", dest="openai_api_key", default=None, action="store")
+    parser.add_argument("--mcp-api-key", dest="mcp_api_key", default=None, action="store")
+    
+    # Test parsing with API keys
+    args = parser.parse_args([
+        "--openai-api-key", "test-openai-key",
+        "--mcp-api-key", "test-mcp-key",
+        "--adapter", "xaibo.server.adapters.openai.OpenAiApiAdapter"
+    ])
+    
+    assert args.openai_api_key == "test-openai-key"
+    assert args.mcp_api_key == "test-mcp-key"
+    assert args.adapters == ["xaibo.server.adapters.openai.OpenAiApiAdapter"]
+    assert args.agent_dir == "./agents"
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+    assert args.debug is False
+    
+    # Test parsing without API keys (should default to None)
+    args = parser.parse_args([])
+    assert args.openai_api_key is None
+    assert args.mcp_api_key is None
+
+
+def test_web_server_integration_with_real_adapters(xaibo_instance, temp_agent_dir):
+    """Integration test with real adapter classes"""
+    # Test that the server can instantiate real adapters with API keys
+    server = XaiboWebServer(
+        xaibo=xaibo_instance,
+        adapters=[
+            "xaibo.server.adapters.openai.OpenAiApiAdapter",
+            "xaibo.server.adapters.mcp.McpApiAdapter"
+        ],
+        agent_dir=temp_agent_dir,
+        openai_api_key="integration-openai-key",
+        mcp_api_key="integration-mcp-key"
+    )
+    
+    # Verify the server was created successfully
+    assert server.openai_api_key == "integration-openai-key"
+    assert server.mcp_api_key == "integration-mcp-key"
+    assert isinstance(server.app, FastAPI)
+
+
+def test_web_server_mixed_scenario_one_adapter_with_key_one_without(xaibo_instance, temp_agent_dir):
+    """Test mixed scenario where one adapter has API key and one doesn't"""
+    with patch('xaibo.server.web.get_class_by_path') as mock_get_class:
+        mock_openai_class = Mock()
+        mock_openai_instance = Mock()
+        mock_openai_class.return_value = mock_openai_instance
+        mock_openai_class.__name__ = "OpenAiApiAdapter"
+        
+        mock_other_class = Mock()
+        mock_other_instance = Mock()
+        mock_other_class.return_value = mock_other_instance
+        mock_other_class.__name__ = "SomeOtherAdapter"
+        
+        def side_effect(path):
+            if "openai" in path.lower():
+                return mock_openai_class
+            else:
+                return mock_other_class
+        
+        mock_get_class.side_effect = side_effect
+        
+        server = XaiboWebServer(
+            xaibo=xaibo_instance,
+            adapters=[
+                "xaibo.server.adapters.openai.OpenAiApiAdapter",
+                "some.other.SomeOtherAdapter"
+            ],
+            agent_dir=temp_agent_dir,
+            openai_api_key="test-openai-key",
+            mcp_api_key=None  # No MCP key provided
+        )
+        
+        # Verify OpenAI adapter got the API key
+        mock_openai_class.assert_called_once_with(xaibo_instance, api_key="test-openai-key")
+        
+        # Verify other adapter didn't get any API key
+        mock_other_class.assert_called_once_with(xaibo_instance)
+        
+        # Verify both adapters were adapted
+        mock_openai_instance.adapt.assert_called_once_with(server.app)
+        mock_other_instance.adapt.assert_called_once_with(server.app)


### PR DESCRIPTION
Introduced optional API key authentication for the OpenAI and MCP adapters to enhance security for API endpoints. Updated the web server to accept and pass API keys to the relevant adapters via new optional arguments `--openai-api-key` and `--mcp-api-key`. Routes requiring authentication now properly verify API keys.