### PR TITLE
🐛 Fix blank page on client-side navigation to agent profile

### DIFF
--- a/ui/src/routes/agents/[id]/+page.svelte
+++ b/ui/src/routes/agents/[id]/+page.svelte
@@ -6,7 +6,7 @@
 
     let {data} = $props();
     let {AgentConfig, DebugTrace} = $derived(data);
-    let {debugLog} = $derived($DebugTrace.data)
+    let debugLog = $derived($DebugTrace?.data?.debugLog);
 
     let debugClear = new ClearDebugLogStore();
     async function clearLog() {
@@ -21,7 +21,7 @@
 
 <PageHeader title={page.params.id} />
 <div class="flex h-full w-full flex-col pr-4 pl-4 overflow-auto">
-    <EventSequenceRenderer events={debugLog.events} onClear={clearLog}/>
+    <EventSequenceRenderer events={debugLog?.events ?? []} onClear={() => { clearLog() }}/>
 </div>
 
 


### PR DESCRIPTION
Add null safety to DebugTrace store data access in /agents/[id] page. During client-side navigation, the Houdini store data can briefly be null before the GraphQL query resolves, causing a TypeError that crashes the component.