### PR TITLE
fix(tools): never crash list_tools on string or exotic annotations

### DIFF
--- a/src/xaibo/primitives/modules/memory/__init__.py
+++ b/src/xaibo/primitives/modules/memory/__init__.py
@@ -2,24 +2,33 @@ from .numpy_vector_index import *
 from .vector_memory import *
 from .memory_provider import *
 
-try:
-    from .token_chunker import *
-except ImportError:
-    pass
-
-try:
-    from .sentence_transformer_embedder import *
-except ImportError:
-    pass
-
-try:
-    from .huggingface_embedder import *
-except ImportError:
-    pass
+# The modules below pull heavy optional dependencies (tiktoken, torch,
+# sentence-transformers, openai). Importing them eagerly makes every import
+# of this package pay their cost — e.g. the config loader imports a memory
+# submodule while parsing agent configs, which used to drag torch (and its
+# NumPy-version warning wall) into agents that never embed anything.
+# PEP 562 lazy loading defers each import until the class is first accessed.
+_LAZY_EXPORTS = {
+    "TokenChunker": ".token_chunker",
+    "SentenceTransformerEmbedder": ".sentence_transformer_embedder",
+    "HuggingFaceEmbedder": ".huggingface_embedder",
+    "OpenAIEmbedder": ".openai_embedder",
+}
 
 
-try:
-    from .openai_embedder import *
-except ImportError:
-    pass
+def __getattr__(name):
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+    try:
+        module = importlib.import_module(target, __name__)
+    except ImportError as e:
+        # Same visible behavior as the old guarded eager imports: when the
+        # optional dependency is missing, the name does not exist here.
+        raise AttributeError(f"{name} is unavailable: {e}") from e
+    return getattr(module, name)
 
+
+def __dir__():
+    return sorted(set(globals()) | set(_LAZY_EXPORTS))

--- a/src/xaibo/primitives/modules/tools/python_tool_provider.py
+++ b/src/xaibo/primitives/modules/tools/python_tool_provider.py
@@ -1,6 +1,8 @@
 import importlib
 import inspect
 import sys
+import types
+import typing
 from typing import Any, Dict, List
 
 import docstring_parser
@@ -116,10 +118,6 @@ class PythonToolProvider(ToolProviderProtocol):
                 description=param_docs.get(param.name, ""),
                 required=param.default == inspect.Parameter.empty
             )
-            if parameters[param.name].type == 'str':
-                parameters[param.name].type = 'string'
-            elif parameters[param.name].type == 'int':
-                parameters[param.name].type = 'integer'
 
         return Tool(
             name=self._get_tool_name(fn),
@@ -127,20 +125,51 @@ class PythonToolProvider(ToolProviderProtocol):
             parameters=parameters
         )
 
-    @staticmethod
-    def _annotation_type_name(annotation) -> str:
-        """Best-effort type name for a parameter annotation.
+    # Python type names → JSON Schema types. Anything outside JSON Schema's
+    # {string,integer,number,boolean,array,object,null} gets rejected by
+    # providers with strict schema validation (OpenAI 400s the whole request
+    # over a single 'Optional'/'dict'/'list' type), so unknowns degrade to
+    # 'string' — never to an invalid schema.
+    _JSON_SCHEMA_TYPES = {
+        'str': 'string', 'int': 'integer', 'float': 'number', 'bool': 'boolean',
+        'list': 'array', 'tuple': 'array', 'set': 'array', 'frozenset': 'array',
+        'dict': 'object', 'mapping': 'object', 'sequence': 'array',
+        'iterable': 'array', 'bytes': 'string', 'none': 'null', 'nonetype': 'null',
+        'any': 'string', 'string': 'string', 'integer': 'integer',
+        'number': 'number', 'boolean': 'boolean', 'array': 'array',
+        'object': 'object', 'null': 'null',
+    }
 
-        Never raises: annotations may be strings (quoted annotations, or any
-        module using `from __future__ import annotations`) or typing
-        constructs without a usable __name__ — listing tools must not crash
-        on legal Python.
+    @classmethod
+    def _annotation_type_name(cls, annotation) -> str:
+        """JSON Schema type for a parameter annotation.
+
+        Never raises, and never emits a type outside JSON Schema's vocabulary.
+        Handles real typing objects via get_origin/get_args (so
+        Optional[list[str]] maps to 'array' on every Python version, instead of
+        leaking 'Optional'/'Union' from __name__), plain classes, and string
+        annotations (quoted, or any module using
+        `from __future__ import annotations`).
         """
         if annotation is inspect.Parameter.empty:
-            return "any"
+            return "string"
         if isinstance(annotation, str):
-            return annotation
-        return getattr(annotation, "__name__", None) or str(annotation)
+            token = annotation.strip()
+            lowered = token.lower()
+            if lowered.startswith('optional[') and lowered.endswith(']'):
+                return cls._annotation_type_name(token[9:-1])
+            return cls._JSON_SCHEMA_TYPES.get(lowered.split('[', 1)[0], 'string')
+        origin = typing.get_origin(annotation)
+        union_kinds = (typing.Union, getattr(types, 'UnionType', typing.Union))
+        if origin in union_kinds:
+            args = [a for a in typing.get_args(annotation) if a is not type(None)]
+            return cls._annotation_type_name(args[0]) if args else 'string'
+        if origin is not None:
+            annotation = origin
+        if annotation is type(None):
+            return 'null'
+        name = getattr(annotation, '__name__', None) or str(annotation)
+        return cls._JSON_SCHEMA_TYPES.get(name.lower(), 'string')
 
     def _get_tool_name(self, fn) -> str:
         """Get the full tool name including module path"""

--- a/src/xaibo/primitives/modules/tools/python_tool_provider.py
+++ b/src/xaibo/primitives/modules/tools/python_tool_provider.py
@@ -112,7 +112,7 @@ class PythonToolProvider(ToolProviderProtocol):
         parameters = {}
         for param in inspect.signature(fn).parameters.values():
             parameters[param.name] = ToolParameter(
-                type=param.annotation.__name__ if param.annotation != inspect._empty else "any",
+                type=self._annotation_type_name(param.annotation),
                 description=param_docs.get(param.name, ""),
                 required=param.default == inspect.Parameter.empty
             )
@@ -126,6 +126,21 @@ class PythonToolProvider(ToolProviderProtocol):
             description=docstr.description or "",
             parameters=parameters
         )
+
+    @staticmethod
+    def _annotation_type_name(annotation) -> str:
+        """Best-effort type name for a parameter annotation.
+
+        Never raises: annotations may be strings (quoted annotations, or any
+        module using `from __future__ import annotations`) or typing
+        constructs without a usable __name__ — listing tools must not crash
+        on legal Python.
+        """
+        if annotation is inspect.Parameter.empty:
+            return "any"
+        if isinstance(annotation, str):
+            return annotation
+        return getattr(annotation, "__name__", None) or str(annotation)
 
     def _get_tool_name(self, fn) -> str:
         """Get the full tool name including module path"""

--- a/tests/tools/test_python_tools.py
+++ b/tests/tools/test_python_tools.py
@@ -206,6 +206,67 @@ async def test_mixed_tool_sources():
 
 
 @pytest.mark.asyncio
+async def test_parameter_types_are_valid_json_schema():
+    """Strict providers (OpenAI) reject any type outside JSON Schema's vocabulary —
+    one 'Optional'/'dict'/'list' 400s the whole request. Mirrors the real failure:
+    gpt-5.5 rejecting github_tools.create_issue over Optional[list[str]]."""
+    from typing import Optional
+
+    @tool
+    def create_issue(repo: str, title: str, count: int, score: float, flag: bool,
+                     labels: Optional[list[str]] = None, meta: dict = None, anything=None):
+        """File an issue
+
+        Args:
+            repo: repository
+            title: issue title
+            count: how many
+            score: how good
+            flag: whether
+            labels: labels to apply
+            meta: extra fields
+            anything: untyped
+        """
+        return None
+
+    provider = PythonToolProvider({"tool_functions": [create_issue]})
+    tools = await provider.list_tools()
+    p = tools[0].parameters
+
+    assert p["repo"].type == "string"
+    assert p["count"].type == "integer"
+    assert p["score"].type == "number"
+    assert p["flag"].type == "boolean"
+    assert p["labels"].type == "array", "Optional[list[str]] must map to array, not 'Optional'"
+    assert p["meta"].type == "object"
+    assert p["anything"].type == "string"
+
+    valid = {"string", "integer", "number", "boolean", "array", "object", "null"}
+    assert all(q.type in valid for q in p.values()), {k: q.type for k, q in p.items()}
+
+
+@pytest.mark.asyncio
+async def test_string_annotation_complex_types_map_to_json_schema():
+    """String annotations (future-import modules) with typing constructs must also
+    land on valid JSON Schema types."""
+    @tool
+    def fancy(labels: "Optional[list[str]]" = None, meta: "dict" = None):
+        """Fancy
+
+        Args:
+            labels: labels
+            meta: meta
+        """
+        return None
+
+    provider = PythonToolProvider({"tool_functions": [fancy]})
+    tools = await provider.list_tools()
+    p = tools[0].parameters
+    assert p["labels"].type == "array"
+    assert p["meta"].type == "object"
+
+
+@pytest.mark.asyncio
 async def test_string_annotations_do_not_crash():
     """Quoted annotations (or `from __future__ import annotations` in the
     tool module) make param.annotation a *string* at runtime; list_tools

--- a/tests/tools/test_python_tools.py
+++ b/tests/tools/test_python_tools.py
@@ -203,3 +203,28 @@ async def test_mixed_tool_sources():
     result = await provider.execute_tool(divide_tool.name, {"numerator": 10, "denominator": 0})
     assert result.success is False
     assert "divide by zero" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_string_annotations_do_not_crash():
+    """Quoted annotations (or `from __future__ import annotations` in the
+    tool module) make param.annotation a *string* at runtime; list_tools
+    must map them like real classes, not crash with AttributeError."""
+    @tool
+    def shout(text: "str", times: "int" = 1):
+        """Repeat text loudly
+
+        Args:
+            text: What to shout
+            times: How many times
+        """
+        return (text.upper() + "! ") * times
+
+    provider = PythonToolProvider({"tool_functions": [shout]})
+    tools = await provider.list_tools()
+    assert len(tools) == 1
+    params = tools[0].parameters
+    assert params["text"].type == "string"
+    assert params["times"].type == "integer"
+    assert params["text"].required is True
+    assert params["times"].required is False

--- a/ui/package.json
+++ b/ui/package.json
@@ -60,14 +60,5 @@
     "vite": "^7.3.1",
     "vitest": "^3.2.4"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
-    "overrides": {
-      "ajv@<8.18.0": ">=8.18.0",
-      "cookie@<0.7.0": ">=0.7.0",
-      "dompurify@>=3.1.3 <=3.3.1": ">=3.3.2"
-    }
-  }
+  "packageManager": "pnpm@11.1.3"
 }

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+# pnpm >= 10 no longer reads the "pnpm" field in package.json — settings moved
+# here (https://pnpm.io/settings). The lockfile's config hash derives from
+# these, so CI's frozen install fails if they drift or live in the old spot.
+# allowBuilds: only esbuild may run install scripts (parity with the previous
+# onlyBuiltDependencies policy); the rest work fine without their postinstall.
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: true
+  msw: false
+  svelte-preprocess: false
+overrides:
+  "ajv@<8.18.0": ">=8.18.0"
+  "cookie@<0.7.0": ">=0.7.0"
+  "dompurify@>=3.1.3 <=3.3.1": ">=3.3.2"


### PR DESCRIPTION
Four robustness fixes in the tool provider, LLM client, and memory package, plus a CI repair:

**1. `list_tools` no longer crashes on string annotations** (`5409ffe`) — `param.annotation.__name__` raised `AttributeError` for modules using `from __future__ import annotations`; one such tool broke every interaction with the agent.

**2. Tool schemas only emit valid JSON Schema types** (`17f6a9a`) — parameter types carried raw Python names (`Optional`, `dict`, `list`, `float`); strict providers (OpenAI) reject the entire request over a single invalid type. Real typing objects resolve via `get_origin`/`get_args` (version-independent), string annotations map through a vocabulary table, unknowns degrade to `string`.

**3. Tool-call arguments parse tolerantly** (`791b444`) — models routinely emit raw control characters (literal newlines) inside JSON string values of tool-call arguments; strict `json.loads` rejected those and **one malformed tool call aborted the entire turn**. `strict=False`, with a `{"_raw": ...}` degradation for anything still unparseable, so the tool reports a bad argument instead of the run dying.

**4. The memory package no longer imports torch eagerly** (`aa5bca6`) — PEP 562 lazy loading for the torch/tiktoken/openai-backed embedders; config loading stops paying the torch import (and NumPy ABI warnings) in processes that never embed.

**CI** (`0ab0005`): pnpm ≥ 10 stopped reading the `pnpm` field in `package.json`; settings moved to `pnpm-workspace.yaml` and `packageManager` pinned. Pipeline is green.

Tests: tools 10/10, new llm argument-parsing suite 5/5, all on Python 3.11.