### PR TITLE
fix(llm): surface the response body when a completion has no choices

### DIFF
--- a/src/xaibo/primitives/modules/llm/openai.py
+++ b/src/xaibo/primitives/modules/llm/openai.py
@@ -51,9 +51,27 @@ class OpenAILLM(LLMProtocol):
         )
         
         # Store any additional parameters as default kwargs
-        self.default_kwargs = {k: v for k, v in config.items() 
+        self.default_kwargs = {k: v for k, v in config.items()
                               if k not in ['api_key', 'model', 'base_url', 'timeout']}
-    
+
+    @staticmethod
+    def _require_choices(response) -> None:
+        """Fail loudly when a completion response carries no choices.
+
+        Some OpenAI-compatible gateways return upstream error bodies with
+        HTTP 200. The SDK constructs those leniently (choices ends up None),
+        so subscripting raises a bare "'NoneType' object is not subscriptable"
+        that hides the actual upstream error. Surface the body instead — it
+        usually contains the real reason (rate limit, quota, provider error).
+        """
+        if getattr(response, "choices", None):
+            return
+        try:
+            detail = response.model_dump_json(exclude_none=True)
+        except Exception:
+            detail = repr(response)
+        raise RuntimeError(f"LLM API returned a completion without choices: {detail[:500]}")
+
     def _prepare_messages(self, messages: List[LLMMessage]) -> List[Dict[str, Any]]:
         """Convert our messages to OpenAI format"""
         prepared_messages = []
@@ -215,6 +233,7 @@ class OpenAILLM(LLMProtocol):
             response: ChatCompletion = await self.client.chat.completions.create(**kwargs)
             
             # Process the response
+            self._require_choices(response)
             choice = response.choices[0]
             message = choice.message
             finish_reason = choice.finish_reason

--- a/src/xaibo/primitives/modules/llm/openai.py
+++ b/src/xaibo/primitives/modules/llm/openai.py
@@ -55,6 +55,27 @@ class OpenAILLM(LLMProtocol):
                               if k not in ['api_key', 'model', 'base_url', 'timeout']}
 
     @staticmethod
+    def _parse_tool_arguments(raw) -> Optional[Dict[str, Any]]:
+        """Parse model-emitted tool-call arguments tolerantly.
+
+        Models routinely emit raw control characters (literal newlines) inside
+        JSON string values; strict json.loads rejects those even though the
+        arguments are otherwise perfectly usable. Parameterless tools arrive
+        with empty arguments, which strict parsing also rejects — those must
+        become {} rather than dropping the call.
+
+        Returns the parsed dict, or None when the arguments are irrecoverable
+        (the caller skips that tool call with a warning).
+        """
+        if raw is None or raw == "":
+            return {}
+        try:
+            parsed = json.loads(raw, strict=False)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
     def _require_choices(response) -> None:
         """Fail loudly when a completion response carries no choices.
 
@@ -262,20 +283,21 @@ class OpenAILLM(LLMProtocol):
                 else:
                     parsed_tool_calls = []
                     for tool_call in message.tool_calls:
-                        try:
-                            parsed_tool_calls.append(
-                                LLMFunctionCall(
-                                    id=tool_call.id,
-                                    name=tool_call.function.name,
-                                    arguments=json.loads(tool_call.function.arguments)
-                                )
-                            )
-                        except json.JSONDecodeError as e:
+                        arguments = self._parse_tool_arguments(tool_call.function.arguments)
+                        if arguments is None:
                             logger.warning(
                                 f"Skipping tool call '{tool_call.function.name}' — "
-                                f"malformed JSON in arguments: {e}. "
+                                f"malformed JSON in arguments. "
                                 f"Raw arguments: {tool_call.function.arguments!r}"
                             )
+                            continue
+                        parsed_tool_calls.append(
+                            LLMFunctionCall(
+                                id=tool_call.id,
+                                name=tool_call.function.name,
+                                arguments=arguments
+                            )
+                        )
 
                     tool_calls = parsed_tool_calls if parsed_tool_calls else None
 

--- a/tests/llms/test_openai_no_choices.py
+++ b/tests/llms/test_openai_no_choices.py
@@ -1,0 +1,62 @@
+"""A completion response without choices must raise a useful error.
+
+Some OpenAI-compatible gateways return upstream error bodies (rate limits,
+provider failures) with HTTP 200. The SDK constructs those leniently, leaving
+`choices` as None/absent, and `response.choices[0]` then raised a bare
+"'NoneType' object is not subscriptable" that hid the actual upstream error.
+"""
+from types import SimpleNamespace
+
+import pytest
+from openai.types.chat import ChatCompletion
+
+from xaibo.primitives.modules.llm.openai import OpenAILLM
+
+
+def test_none_choices_raises_with_body_detail():
+    response = SimpleNamespace(
+        choices=None,
+        model_dump_json=lambda exclude_none: '{"code": "rate_limit_daily", "message": "Error code: 429"}',
+    )
+    with pytest.raises(RuntimeError) as exc:
+        OpenAILLM._require_choices(response)
+    assert "without choices" in str(exc.value)
+    assert "rate_limit_daily" in str(exc.value)
+
+
+def test_empty_choices_list_raises():
+    response = SimpleNamespace(
+        choices=[],
+        model_dump_json=lambda exclude_none: "{}",
+    )
+    with pytest.raises(RuntimeError):
+        OpenAILLM._require_choices(response)
+
+
+def test_real_sdk_lenient_construction_raises():
+    # What the SDK actually produces for an error body returned with 200:
+    # construct() doesn't validate, so `choices` is simply absent.
+    response = ChatCompletion.construct(code="rate_limit_daily", message="Error code: 429 - {...}")
+    with pytest.raises(RuntimeError) as exc:
+        OpenAILLM._require_choices(response)
+    assert "rate_limit_daily" in str(exc.value)
+
+
+def test_detail_falls_back_to_repr_when_dump_fails():
+    class Undumpable:
+        choices = None
+
+        def model_dump_json(self, **kwargs):
+            raise ValueError("nope")
+
+        def __repr__(self):
+            return "<weird body>"
+
+    with pytest.raises(RuntimeError) as exc:
+        OpenAILLM._require_choices(Undumpable())
+    assert "<weird body>" in str(exc.value)
+
+
+def test_normal_response_passes():
+    response = SimpleNamespace(choices=[SimpleNamespace(message=None)])
+    OpenAILLM._require_choices(response)  # must not raise

--- a/tests/llms/test_openai_tool_arguments.py
+++ b/tests/llms/test_openai_tool_arguments.py
@@ -1,0 +1,34 @@
+"""Tolerant parsing of model-emitted tool-call arguments.
+
+Models emit raw control characters (literal newlines) inside JSON string
+values; strict json.loads rejects those and the otherwise-valid tool call got
+skipped. Parameterless tools arrive with empty arguments, which strict parsing
+also rejects — those must become {} rather than dropping the call. Only
+irrecoverable arguments return None (the caller skips that call with a warning).
+"""
+from xaibo.primitives.modules.llm.openai import OpenAILLM
+
+
+def test_control_characters_inside_strings_parse():
+    raw = '{"text": "line one\nline two"}'  # REAL newline inside the JSON string value
+    parsed = OpenAILLM._parse_tool_arguments(raw)
+    assert parsed == {"text": "line one\nline two"}
+
+
+def test_valid_json_unchanged():
+    assert OpenAILLM._parse_tool_arguments('{"a": 1, "b": "x"}') == {"a": 1, "b": "x"}
+
+
+def test_empty_arguments_mean_no_parameters():
+    assert OpenAILLM._parse_tool_arguments("") == {}
+    assert OpenAILLM._parse_tool_arguments(None) == {}
+
+
+def test_garbage_returns_none_for_skip():
+    assert OpenAILLM._parse_tool_arguments("not json at all {{{") is None
+
+
+def test_non_dict_json_returns_none_for_skip():
+    # A bare list/number can't be passed as kwargs to any tool.
+    assert OpenAILLM._parse_tool_arguments("[1, 2]") is None
+    assert OpenAILLM._parse_tool_arguments("42") is None


### PR DESCRIPTION
Two resilience fixes in the OpenAI adapter's response handling, both observed with OpenAI-compatible gateways in production use.

### 1. A completion without `choices` now raises a useful error

Some OpenAI-compatible gateways return upstream error bodies (rate limits, provider failures) with HTTP 200. The SDK constructs those leniently, so `choices` ends up `None`/absent and `response.choices[0]` raises a bare `'NoneType' object is not subscriptable` — the actual upstream error (sitting right there in the body) never reaches the caller or the logs.

`OpenAILLM.generate` now checks before subscripting and raises a `RuntimeError` carrying the response body (truncated to 500 chars):

```
RuntimeError: LLM API returned a completion without choices: {"code": "rate_limit_daily", "message": "Error code: 429 - ..."}
```

The streaming path already guards (`if chunk.choices and ...`), so only `generate` needed it.

### 2. Tool-call argument parsing tolerates recoverable malformations

The strict `json.loads` in the tool-call path dropped two recoverable cases (skipping the call with only a log line):

- **raw control characters** (literal newlines) inside JSON string values — models emit these routinely, and `strict=False` parses them fine;
- **empty arguments** from parameterless tool calls — `json.loads("")` raises, but the right reading is `{}`, not dropping the call.

Truly irrecoverable arguments (garbage, non-dict JSON like a bare list) keep the existing skip-with-warning behavior from #33; a bare non-dict additionally can't crash `LLMFunctionCall` validation anymore.

### Tests

`test_openai_no_choices.py` (incl. the SDK's real lenient `construct()` path) and `test_openai_tool_arguments.py`.

Note: commit `70f52e6` on the already-merged #35 branch is a stray push of the first fix made before noticing the merge — ignore that branch head; this PR supersedes it, rebased onto current `main` (composes with the `finish_reason` handling from #33).