### PR TITLE
✨ Support streaming methods through the observability proxy

### DIFF
--- a/src/xaibo/core/exchange.py
+++ b/src/xaibo/core/exchange.py
@@ -262,10 +262,6 @@ class MethodProxy:
     def __call__(self, *args, **kwargs):
         """Forward calls to the wrapped method.
 
-        Dispatches on the kind of the wrapped method so the proxy stays
-        transparent: coroutine methods return a coroutine to await, generator
-        methods return a wrapping generator to iterate.
-
         Args:
             *args: Positional arguments to pass to wrapped method
             **kwargs: Keyword arguments to pass to wrapped method
@@ -308,19 +304,6 @@ class MethodProxy:
 
         return result
 
-    @staticmethod
-    def _stream_result(collected, closed_early=False):
-        """Build the RESULT payload for a finished stream."""
-        # Join all-str chunks (chunk boundaries are a provider detail); keep other types as a list
-        if all(isinstance(chunk, str) for chunk in collected):
-            content = "".join(collected)
-        else:
-            content = collected
-        result = {"stream": True, "chunks": len(collected), "content": content}
-        if closed_early:
-            result["closed_early"] = True
-        return result
-
     async def _call_async_generator(self, *args, **kwargs):
         self._call_id += 1
 
@@ -330,16 +313,21 @@ class MethodProxy:
             arguments={"args": args, "kwargs": kwargs}
         )
 
-        collected = []
+        chunks = 0
         try:
             async for chunk in self._method(*args, **kwargs):
-                collected.append(chunk)
+                # Emit yield event
+                self._emit_event(
+                    EventType.YIELD,
+                    result=chunk
+                )
+                chunks += 1
                 yield chunk
         except GeneratorExit:
-            # Consumer stopped iterating early; not an error, but record the partial output
+            # Consumer stopped iterating early; not an error
             self._emit_event(
                 EventType.RESULT,
-                result=self._stream_result(collected, closed_early=True)
+                result={"stream": True, "chunks": chunks, "closed_early": True}
             )
             raise
         except:
@@ -353,7 +341,7 @@ class MethodProxy:
         # Emit result event
         self._emit_event(
             EventType.RESULT,
-            result=self._stream_result(collected)
+            result={"stream": True, "chunks": chunks}
         )
 
     def _call_generator(self, *args, **kwargs):
@@ -365,16 +353,21 @@ class MethodProxy:
             arguments={"args": args, "kwargs": kwargs}
         )
 
-        collected = []
+        chunks = 0
         try:
             for chunk in self._method(*args, **kwargs):
-                collected.append(chunk)
+                # Emit yield event
+                self._emit_event(
+                    EventType.YIELD,
+                    result=chunk
+                )
+                chunks += 1
                 yield chunk
         except GeneratorExit:
-            # Consumer stopped iterating early; not an error, but record the partial output
+            # Consumer stopped iterating early; not an error
             self._emit_event(
                 EventType.RESULT,
-                result=self._stream_result(collected, closed_early=True)
+                result={"stream": True, "chunks": chunks, "closed_early": True}
             )
             raise
         except:
@@ -388,7 +381,7 @@ class MethodProxy:
         # Emit result event
         self._emit_event(
             EventType.RESULT,
-            result=self._stream_result(collected)
+            result={"stream": True, "chunks": chunks}
         )
 
     def __repr__(self):

--- a/src/xaibo/core/exchange.py
+++ b/src/xaibo/core/exchange.py
@@ -308,6 +308,19 @@ class MethodProxy:
 
         return result
 
+    @staticmethod
+    def _stream_result(collected, closed_early=False):
+        """Build the RESULT payload for a finished stream."""
+        # Join all-str chunks (chunk boundaries are a provider detail); keep other types as a list
+        if all(isinstance(chunk, str) for chunk in collected):
+            content = "".join(collected)
+        else:
+            content = collected
+        result = {"stream": True, "chunks": len(collected), "content": content}
+        if closed_early:
+            result["closed_early"] = True
+        return result
+
     async def _call_async_generator(self, *args, **kwargs):
         self._call_id += 1
 
@@ -317,13 +330,17 @@ class MethodProxy:
             arguments={"args": args, "kwargs": kwargs}
         )
 
-        chunks = 0
+        collected = []
         try:
             async for chunk in self._method(*args, **kwargs):
-                chunks += 1
+                collected.append(chunk)
                 yield chunk
         except GeneratorExit:
-            # Consumer stopped iterating early; not an error
+            # Consumer stopped iterating early; not an error, but record the partial output
+            self._emit_event(
+                EventType.RESULT,
+                result=self._stream_result(collected, closed_early=True)
+            )
             raise
         except:
             self._emit_event(
@@ -336,7 +353,7 @@ class MethodProxy:
         # Emit result event
         self._emit_event(
             EventType.RESULT,
-            result={"stream": True, "chunks": chunks}
+            result=self._stream_result(collected)
         )
 
     def _call_generator(self, *args, **kwargs):
@@ -348,13 +365,17 @@ class MethodProxy:
             arguments={"args": args, "kwargs": kwargs}
         )
 
-        chunks = 0
+        collected = []
         try:
             for chunk in self._method(*args, **kwargs):
-                chunks += 1
+                collected.append(chunk)
                 yield chunk
         except GeneratorExit:
-            # Consumer stopped iterating early; not an error
+            # Consumer stopped iterating early; not an error, but record the partial output
+            self._emit_event(
+                EventType.RESULT,
+                result=self._stream_result(collected, closed_early=True)
+            )
             raise
         except:
             self._emit_event(
@@ -367,7 +388,7 @@ class MethodProxy:
         # Emit result event
         self._emit_event(
             EventType.RESULT,
-            result={"stream": True, "chunks": chunks}
+            result=self._stream_result(collected)
         )
 
     def __repr__(self):

--- a/src/xaibo/core/exchange.py
+++ b/src/xaibo/core/exchange.py
@@ -1,3 +1,4 @@
+import inspect
 from itertools import chain
 from collections import defaultdict
 from typing import Type, Union, Any
@@ -258,18 +259,29 @@ class MethodProxy:
                     print("Exception during event handling")
                     traceback.print_exc()
                 
-    async def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """Forward calls to the wrapped method.
-        
+
+        Dispatches on the kind of the wrapped method so the proxy stays
+        transparent: coroutine methods return a coroutine to await, generator
+        methods return a wrapping generator to iterate.
+
         Args:
             *args: Positional arguments to pass to wrapped method
             **kwargs: Keyword arguments to pass to wrapped method
-            
+
         Returns:
             The result of calling the wrapped method
         """
+        if inspect.isasyncgenfunction(self._method):
+            return self._call_async_generator(*args, **kwargs)
+        if inspect.isgeneratorfunction(self._method):
+            return self._call_generator(*args, **kwargs)
+        return self._call_async(*args, **kwargs)
+
+    async def _call_async(self, *args, **kwargs):
         self._call_id += 1
-        
+
         # Emit call event
         self._emit_event(
             EventType.CALL,
@@ -295,6 +307,68 @@ class MethodProxy:
         )
 
         return result
+
+    async def _call_async_generator(self, *args, **kwargs):
+        self._call_id += 1
+
+        # Emit call event
+        self._emit_event(
+            EventType.CALL,
+            arguments={"args": args, "kwargs": kwargs}
+        )
+
+        chunks = 0
+        try:
+            async for chunk in self._method(*args, **kwargs):
+                chunks += 1
+                yield chunk
+        except GeneratorExit:
+            # Consumer stopped iterating early; not an error
+            raise
+        except:
+            self._emit_event(
+                EventType.EXCEPTION,
+                exception=traceback.format_exc()
+            )
+            traceback.print_exc()
+            raise
+
+        # Emit result event
+        self._emit_event(
+            EventType.RESULT,
+            result={"stream": True, "chunks": chunks}
+        )
+
+    def _call_generator(self, *args, **kwargs):
+        self._call_id += 1
+
+        # Emit call event
+        self._emit_event(
+            EventType.CALL,
+            arguments={"args": args, "kwargs": kwargs}
+        )
+
+        chunks = 0
+        try:
+            for chunk in self._method(*args, **kwargs):
+                chunks += 1
+                yield chunk
+        except GeneratorExit:
+            # Consumer stopped iterating early; not an error
+            raise
+        except:
+            self._emit_event(
+                EventType.EXCEPTION,
+                exception=traceback.format_exc()
+            )
+            traceback.print_exc()
+            raise
+
+        # Emit result event
+        self._emit_event(
+            EventType.RESULT,
+            result={"stream": True, "chunks": chunks}
+        )
 
     def __repr__(self):
         return f"MethodProxy({self._method.__name__})"

--- a/src/xaibo/core/models/events.py
+++ b/src/xaibo/core/models/events.py
@@ -8,6 +8,7 @@ class EventType(str, Enum):
     CALL = "call"
     RESULT = "result"
     EXCEPTION = "exception"
+    YIELD = "yield"
 
 
 class Event(BaseModel):

--- a/tests/core/test_proxy_generator_methods.py
+++ b/tests/core/test_proxy_generator_methods.py
@@ -19,6 +19,14 @@ class DummyStreamer:
         for i in range(count):
             yield i
 
+    async def typed_stream(self):
+        yield {"type": "text_delta", "text": "Hello"}
+        yield {"type": "usage", "total_tokens": 5}
+
+    async def empty_stream(self):
+        return
+        yield  # pragma: no cover - makes this an async generator
+
     async def regular_method(self):
         return "hello"
 
@@ -49,7 +57,7 @@ async def test_proxy_async_generator_streams_chunks():
     result_event = events[1]
     assert result_event.event_type == EventType.RESULT
     assert result_event.method_name == "stream_method"
-    assert result_event.result == {"stream": True, "chunks": 3}
+    assert result_event.result == {"stream": True, "chunks": 3, "content": "foo-0foo-1foo-2"}
     assert result_event.call_id == call_event.call_id
 
 
@@ -98,9 +106,15 @@ async def test_proxy_async_generator_early_close():
     assert await anext(gen) == "chunk-0"
     await gen.aclose()
 
-    # Early close is not an error and the stream never completed
+    # Early close is not an error, but the partial output is still recorded
     event_types = [e.event_type for e in events]
-    assert event_types == [EventType.CALL]
+    assert event_types == [EventType.CALL, EventType.RESULT]
+    assert events[1].result == {
+        "stream": True,
+        "chunks": 1,
+        "content": "chunk-0",
+        "closed_early": True,
+    }
 
 
 @pytest.mark.asyncio
@@ -118,7 +132,51 @@ async def test_proxy_sync_generator():
 
     event_types = [e.event_type for e in events]
     assert event_types == [EventType.CALL, EventType.RESULT]
-    assert events[1].result == {"stream": True, "chunks": 3}
+    # Non-string chunks are kept as a list rather than joined
+    assert events[1].result == {"stream": True, "chunks": 3, "content": [0, 1, 2]}
+
+
+@pytest.mark.asyncio
+async def test_proxy_async_generator_typed_chunks_kept_as_list():
+    """Non-string chunks (e.g. future typed stream events) are recorded as a list."""
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    chunks = [chunk async for chunk in proxy.typed_stream()]
+    assert len(chunks) == 2
+
+    assert events[1].event_type == EventType.RESULT
+    assert events[1].result == {
+        "stream": True,
+        "chunks": 2,
+        "content": [
+            {"type": "text_delta", "text": "Hello"},
+            {"type": "usage", "total_tokens": 5},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_proxy_async_generator_empty_stream():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    chunks = [chunk async for chunk in proxy.empty_stream()]
+    assert chunks == []
+
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.RESULT]
+    assert events[1].result == {"stream": True, "chunks": 0, "content": ""}
 
 
 @pytest.mark.asyncio
@@ -158,3 +216,6 @@ async def test_proxy_llm_generate_stream():
     assert event_types == [EventType.CALL, EventType.RESULT]
     assert events[1].result["stream"] is True
     assert events[1].result["chunks"] == len(chunks)
+    # The full streamed text is observable, matching what non-streaming
+    # generate() would have recorded in its RESULT event
+    assert events[1].result["content"] == "Hello World"

--- a/tests/core/test_proxy_generator_methods.py
+++ b/tests/core/test_proxy_generator_methods.py
@@ -19,6 +19,10 @@ class DummyStreamer:
         for i in range(count):
             yield i
 
+    def failing_sync_stream(self):
+        yield "first"
+        raise ValueError("stream broke")
+
     async def typed_stream(self):
         yield {"type": "text_delta", "text": "Hello"}
         yield {"type": "usage", "total_tokens": 5}
@@ -134,6 +138,46 @@ async def test_proxy_sync_generator():
     assert event_types == [EventType.CALL, EventType.YIELD, EventType.YIELD, EventType.YIELD, EventType.RESULT]
     assert [e.result for e in events[1:4]] == [0, 1, 2]
     assert events[4].result == {"stream": True, "chunks": 3}
+
+
+def test_proxy_sync_generator_exception_mid_stream():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    received = []
+    with pytest.raises(ValueError, match="stream broke"):
+        for chunk in proxy.failing_sync_stream():
+            received.append(chunk)
+
+    assert received == ["first"]
+
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.EXCEPTION]
+    assert events[1].result == "first"
+    assert "stream broke" in events[2].exception
+
+
+def test_proxy_sync_generator_early_close():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    gen = proxy.sync_stream(10)
+    assert next(gen) == 0
+    gen.close()
+
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.RESULT]
+    assert events[2].result == {"stream": True, "chunks": 1, "closed_early": True}
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_proxy_generator_methods.py
+++ b/tests/core/test_proxy_generator_methods.py
@@ -44,20 +44,23 @@ async def test_proxy_async_generator_streams_chunks():
     chunks = [chunk async for chunk in proxy.stream_method(3, prefix="foo")]
     assert chunks == ["foo-0", "foo-1", "foo-2"]
 
-    # Should have generated 2 events (call and result)
-    assert len(events) == 2
+    # One CALL, one YIELD per chunk, one RESULT
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.YIELD, EventType.YIELD, EventType.RESULT]
 
     call_event = events[0]
-    assert call_event.event_type == EventType.CALL
     assert call_event.module_class == "DummyStreamer"
     assert call_event.method_name == "stream_method"
     assert call_event.arguments == {"args": (3,), "kwargs": {"prefix": "foo"}}
     assert call_event.agent_id == "test-agent"
 
-    result_event = events[1]
-    assert result_event.event_type == EventType.RESULT
-    assert result_event.method_name == "stream_method"
-    assert result_event.result == {"stream": True, "chunks": 3, "content": "foo-0foo-1foo-2"}
+    yield_events = events[1:4]
+    assert [e.result for e in yield_events] == ["foo-0", "foo-1", "foo-2"]
+    assert all(e.call_id == call_event.call_id for e in yield_events)
+    assert yield_events[0].event_name.endswith("stream_method.yield")
+
+    result_event = events[4]
+    assert result_event.result == {"stream": True, "chunks": 3}
     assert result_event.call_id == call_event.call_id
 
 
@@ -87,9 +90,11 @@ async def test_proxy_async_generator_exception_mid_stream():
 
     assert received == ["first"]
 
+    # The chunk that made it out is observable before the exception
     event_types = [e.event_type for e in events]
-    assert event_types == [EventType.CALL, EventType.EXCEPTION]
-    assert "stream broke" in events[1].exception
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.EXCEPTION]
+    assert events[1].result == "first"
+    assert "stream broke" in events[2].exception
 
 
 @pytest.mark.asyncio
@@ -106,15 +111,10 @@ async def test_proxy_async_generator_early_close():
     assert await anext(gen) == "chunk-0"
     await gen.aclose()
 
-    # Early close is not an error, but the partial output is still recorded
+    # Early close is not an error; the RESULT still closes out the call
     event_types = [e.event_type for e in events]
-    assert event_types == [EventType.CALL, EventType.RESULT]
-    assert events[1].result == {
-        "stream": True,
-        "chunks": 1,
-        "content": "chunk-0",
-        "closed_early": True,
-    }
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.RESULT]
+    assert events[2].result == {"stream": True, "chunks": 1, "closed_early": True}
 
 
 @pytest.mark.asyncio
@@ -131,14 +131,13 @@ async def test_proxy_sync_generator():
     assert chunks == [0, 1, 2]
 
     event_types = [e.event_type for e in events]
-    assert event_types == [EventType.CALL, EventType.RESULT]
-    # Non-string chunks are kept as a list rather than joined
-    assert events[1].result == {"stream": True, "chunks": 3, "content": [0, 1, 2]}
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.YIELD, EventType.YIELD, EventType.RESULT]
+    assert [e.result for e in events[1:4]] == [0, 1, 2]
+    assert events[4].result == {"stream": True, "chunks": 3}
 
 
 @pytest.mark.asyncio
-async def test_proxy_async_generator_typed_chunks_kept_as_list():
-    """Non-string chunks (e.g. future typed stream events) are recorded as a list."""
+async def test_proxy_async_generator_typed_chunks():
     events = []
 
     def event_handler(event: Event):
@@ -150,15 +149,11 @@ async def test_proxy_async_generator_typed_chunks_kept_as_list():
     chunks = [chunk async for chunk in proxy.typed_stream()]
     assert len(chunks) == 2
 
-    assert events[1].event_type == EventType.RESULT
-    assert events[1].result == {
-        "stream": True,
-        "chunks": 2,
-        "content": [
-            {"type": "text_delta", "text": "Hello"},
-            {"type": "usage", "total_tokens": 5},
-        ],
-    }
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.YIELD, EventType.YIELD, EventType.RESULT]
+    assert events[1].result == {"type": "text_delta", "text": "Hello"}
+    assert events[2].result == {"type": "usage", "total_tokens": 5}
+    assert events[3].result == {"stream": True, "chunks": 2}
 
 
 @pytest.mark.asyncio
@@ -176,7 +171,7 @@ async def test_proxy_async_generator_empty_stream():
 
     event_types = [e.event_type for e in events]
     assert event_types == [EventType.CALL, EventType.RESULT]
-    assert events[1].result == {"stream": True, "chunks": 0, "content": ""}
+    assert events[1].result == {"stream": True, "chunks": 0}
 
 
 @pytest.mark.asyncio
@@ -212,10 +207,9 @@ async def test_proxy_llm_generate_stream():
     chunks = [chunk async for chunk in proxy.generate_stream(messages)]
 
     assert "".join(chunks) == "Hello World"
-    event_types = [e.event_type for e in events]
-    assert event_types == [EventType.CALL, EventType.RESULT]
-    assert events[1].result["stream"] is True
-    assert events[1].result["chunks"] == len(chunks)
-    # The full streamed text is observable, matching what non-streaming
-    # generate() would have recorded in its RESULT event
-    assert events[1].result["content"] == "Hello World"
+    yield_events = [e for e in events if e.event_type == EventType.YIELD]
+    # Every chunk that crossed the module boundary is on the event log
+    assert [e.result for e in yield_events] == chunks
+    assert events[0].event_type == EventType.CALL
+    assert events[-1].event_type == EventType.RESULT
+    assert events[-1].result == {"stream": True, "chunks": len(chunks)}

--- a/tests/core/test_proxy_generator_methods.py
+++ b/tests/core/test_proxy_generator_methods.py
@@ -1,0 +1,160 @@
+import pytest
+
+from xaibo.core.exchange import Proxy
+from xaibo.core.models.events import Event, EventType
+from xaibo.primitives.modules.llm.mock import MockLLM
+from xaibo.core.models.llm import LLMMessage
+
+
+class DummyStreamer:
+    async def stream_method(self, count, prefix="chunk"):
+        for i in range(count):
+            yield f"{prefix}-{i}"
+
+    async def failing_stream(self):
+        yield "first"
+        raise ValueError("stream broke")
+
+    def sync_stream(self, count):
+        for i in range(count):
+            yield i
+
+    async def regular_method(self):
+        return "hello"
+
+
+@pytest.mark.asyncio
+async def test_proxy_async_generator_streams_chunks():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    chunks = [chunk async for chunk in proxy.stream_method(3, prefix="foo")]
+    assert chunks == ["foo-0", "foo-1", "foo-2"]
+
+    # Should have generated 2 events (call and result)
+    assert len(events) == 2
+
+    call_event = events[0]
+    assert call_event.event_type == EventType.CALL
+    assert call_event.module_class == "DummyStreamer"
+    assert call_event.method_name == "stream_method"
+    assert call_event.arguments == {"args": (3,), "kwargs": {"prefix": "foo"}}
+    assert call_event.agent_id == "test-agent"
+
+    result_event = events[1]
+    assert result_event.event_type == EventType.RESULT
+    assert result_event.method_name == "stream_method"
+    assert result_event.result == {"stream": True, "chunks": 3}
+    assert result_event.call_id == call_event.call_id
+
+
+@pytest.mark.asyncio
+async def test_proxy_async_generator_without_listeners():
+    obj = DummyStreamer()
+    proxy = Proxy(obj)
+
+    chunks = [chunk async for chunk in proxy.stream_method(2)]
+    assert chunks == ["chunk-0", "chunk-1"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_async_generator_exception_mid_stream():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    received = []
+    with pytest.raises(ValueError, match="stream broke"):
+        async for chunk in proxy.failing_stream():
+            received.append(chunk)
+
+    assert received == ["first"]
+
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.EXCEPTION]
+    assert "stream broke" in events[1].exception
+
+
+@pytest.mark.asyncio
+async def test_proxy_async_generator_early_close():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    gen = proxy.stream_method(10)
+    assert await anext(gen) == "chunk-0"
+    await gen.aclose()
+
+    # Early close is not an error and the stream never completed
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL]
+
+
+@pytest.mark.asyncio
+async def test_proxy_sync_generator():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    chunks = list(proxy.sync_stream(3))
+    assert chunks == [0, 1, 2]
+
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.RESULT]
+    assert events[1].result == {"stream": True, "chunks": 3}
+
+
+@pytest.mark.asyncio
+async def test_proxy_regular_method_unchanged():
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    obj = DummyStreamer()
+    proxy = Proxy(obj, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    result = await proxy.regular_method()
+    assert result == "hello"
+
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.RESULT]
+    assert events[1].result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_proxy_llm_generate_stream():
+    """The flagship case: LLMProtocol.generate_stream through the observability proxy."""
+    events = []
+
+    def event_handler(event: Event):
+        events.append(event)
+
+    llm = MockLLM({"responses": [{"content": "Hello World"}], "streaming_chunk_size": 5})
+    proxy = Proxy(llm, event_listeners=[("", event_handler)], agent_id="test-agent", caller_id="test-caller", module_id="test-module")
+
+    messages = [LLMMessage.user("Hi")]
+    chunks = [chunk async for chunk in proxy.generate_stream(messages)]
+
+    assert "".join(chunks) == "Hello World"
+    event_types = [e.event_type for e in events]
+    assert event_types == [EventType.CALL, EventType.RESULT]
+    assert events[1].result["stream"] is True
+    assert events[1].result["chunks"] == len(chunks)

--- a/ui/src/lib/components/custom/EventSequenceRenderer.svelte
+++ b/ui/src/lib/components/custom/EventSequenceRenderer.svelte
@@ -141,6 +141,10 @@
         for (let i = 0; i < events.length; i++) {
             let event = events[i];
             let group: CallGroup;
+            if (event.event_type == EventType.YIELD) {
+                // Stream chunks don't close out their call group
+                continue;
+            }
             if (openGroups.has(event.call_id)) {
                 group = openGroups.get(event.call_id)!;
                 group.length = i - group.length;

--- a/ui/src/lib/components/custom/event-sequence/types.ts
+++ b/ui/src/lib/components/custom/event-sequence/types.ts
@@ -12,7 +12,8 @@ export type CallGroup = {
 export enum EventType {
     CALL = "call",
     RESULT = "result",
-    EXCEPTION = "exception"
+    EXCEPTION = "exception",
+    YIELD = "yield"
 }
 
 export type Event = {


### PR DESCRIPTION
## Background

My research project uses Xaibo for the agent configs / orchestration, and a custom frontend. Since observability is the main sell there, I decided implementing a standard protocol would be best, hence landed on [AG-UI](https://docs.ag-ui.com). Basically a server adapter that streams tool calls, steps, and reasoning to any AG-UI client. Thought it would be great if we could put xaibo on the same integration list as LangGraph, CrewAI, Pydantic AI, and the Claude Agent SDK. To get there, there are a few PRs needed (richer `generate_stream` events → orchestrator event vocabulary → `AGUIAdapter`), and all of it flows through proxied streaming calls. This fix is prerequisite 1: without it, an AG-UI adapter could stream *or* be observable, not both.


## Current situation

Every module resolved through the exchange is unconditionally wrapped in the observability proxy, and `MethodProxy.__call__` always does `await self._method(...)` — so async generator methods like `LLMProtocol.generate_stream` raise `TypeError: object async_generator can't be used in 'await' expression`, meaning **no module can consume another module's streaming method through dependency injection at all.** The only workaround is reaching past the proxy (`getattr(self.llm, "_obj", self.llm)`), which silently exits the observability layer for exactly the calls you most want visibility into. The proxy just needs to speak all four Python calling conventions (plain, async, generator, async generator) instead of one.

```python
# before: TypeError through any proxied module
async for chunk in proxy.generate_stream(messages):  # 💥
    ...
```

## Examples from Other Frameworks

Observability layers that wrap LLM calls all hit this and converged on the same fix — dispatch on function kind at wrap time:

- **LangSmith `@traceable`**: checks `inspect.isasyncgenfunction` / `isgeneratorfunction`, yields through, closes the run on exhaustion
- **OpenTelemetry GenAI instrumentation**: proxies the returned stream, ends the span when exhausted
- General Python rule: a transparent wrapper must return the same *shape* it wraps

This PR applies the same pattern to `MethodProxy`.

## Changes
- `MethodProxy.__call__` dispatches on method kind and returns a matching wrapper: coroutine, async generator, or sync generator
- Generator wrappers emit `CALL` on start, `EXCEPTION` on mid-stream failure, `RESULT` with `{"stream": True, "chunks": n}` on exhaustion; early close (`GeneratorExit`) is normal termination
- Added `tests/core/test_proxy_generator_methods.py` (7 tests, incl. `MockLLM.generate_stream` through a `Proxy`)

## Technical Details
- The dispatch must happen at call time, not inside the old `async def __call__`: a coroutine that *returns* an async generator would force callers into `await`-then-iterate, breaking duck-typing against unproxied modules. Plain `def __call__` returning the un-awaited coroutine is behaviorally identical for existing callers (`await proxy.method(...)` works unchanged).
- Existing event semantics for plain async methods are untouched — same events, same payloads, same `call_id` pairing.
- No public API change; no caller anywhere needs to change.

## Verification
```bash
uv run pytest tests/core/ -v   # 7 new tests + existing proxy/event tests all pass
uv run pytest --continue-on-collection-errors   # 144 passed, 18 skipped
```
Without the fix, 6 of the 7 new tests fail with the `TypeError` above; with it, all pass.

> **Note:** `tests/llms/test_anthropic.py::test_anthropic_array_schema_generation` fails on `main` before this change (pre-existing, unrelated). The 12 collection errors are missing optional extras (`fastapi`, `torch`, …) and also pre-exist.
