### PR TITLE
✨ Add structured response events to ResponseProtocol

### DIFF
--- a/src/xaibo/core/models/response.py
+++ b/src/xaibo/core/models/response.py
@@ -1,5 +1,9 @@
 from enum import Enum
-from typing import BinaryIO, Optional, List
+from typing import BinaryIO, Optional, List, Any, Dict, Literal, Union
+
+from pydantic import BaseModel
+
+from xaibo.core.models.llm import LLMUsage
 
 
 class FileType(Enum):
@@ -19,11 +23,44 @@ class FileAttachment:
         self.type = type
 
 
+class ToolCallEvent(BaseModel):
+    """A tool is about to be executed"""
+    type: Literal["tool_call"] = "tool_call"
+    id: str
+    name: str
+    arguments: Dict[str, Any]
+
+
+class ToolResultEvent(BaseModel):
+    """A tool execution finished"""
+    type: Literal["tool_result"] = "tool_result"
+    id: str
+    name: str
+    success: bool
+    result: Optional[Any] = None
+    error: Optional[str] = None
+
+
+class UsageEvent(LLMUsage):
+    """Token usage reported by an LLM call"""
+    type: Literal["usage"] = "usage"
+
+
+ResponseEvent = Union[
+    ToolCallEvent,
+    ToolResultEvent,
+    UsageEvent,
+]
+
+
 class Response:
-    """Model for responses that can include text and file attachments"""
+    """Model for responses that can include text, file attachments and structured events"""
     text: Optional[str] = None
     attachments: List[FileAttachment] = []
+    events: List[ResponseEvent]
 
-    def __init__(self, text: Optional[str] = None, attachments: Optional[List[FileAttachment]] = None) -> None:
+    def __init__(self, text: Optional[str] = None, attachments: Optional[List[FileAttachment]] = None,
+                 events: Optional[List[ResponseEvent]] = None) -> None:
         self.text = text
         self.attachments = attachments or []
+        self.events = events or []

--- a/src/xaibo/core/protocols/response.py
+++ b/src/xaibo/core/protocols/response.py
@@ -1,6 +1,6 @@
 from typing import Protocol, BinaryIO, runtime_checkable
 
-from xaibo.core.models.response import Response
+from xaibo.core.models.response import Response, ResponseEvent
 
 
 @runtime_checkable
@@ -52,5 +52,17 @@ class ResponseProtocol(Protocol):
 
         Args:
             response: Response object containing text and attachments
+        """
+        ...
+
+    async def respond_event(self, event: ResponseEvent) -> None:
+        """Report a structured event produced while generating the response.
+
+        Events carry the internals of response generation (tool calls, tool
+        results, usage) so that adapters can surface them instead of only
+        the final text.
+
+        Args:
+            event: The event to report
         """
         ...

--- a/src/xaibo/integrations/livekit/llm.py
+++ b/src/xaibo/integrations/livekit/llm.py
@@ -294,6 +294,10 @@ class XaiboLLMStream(llm.LLMStream):
                 """Handle streaming text chunks from the agent"""
                 await chunk_queue.put(text)
 
+            async def respond_event(self, event) -> None:
+                """Agent internals are not forwarded to the voice pipeline"""
+                pass
+
             async def get_response(self):
                 """Return None as we handle streaming via respond_text"""
                 return None

--- a/src/xaibo/primitives/modules/orchestrator/simple_tool_orchestrator.py
+++ b/src/xaibo/primitives/modules/orchestrator/simple_tool_orchestrator.py
@@ -1,8 +1,14 @@
 from xaibo.core.protocols import TextMessageHandlerProtocol, ResponseProtocol, LLMProtocol, ToolProviderProtocol, \
     ConversationHistoryProtocol
 from xaibo.core.models.llm import LLMMessage, LLMOptions, LLMRole, LLMFunctionResult, LLMMessageContentType, LLMMessageContent
+from xaibo.core.models.response import ToolCallEvent, ToolResultEvent, UsageEvent
 
 import json
+
+
+def _json_safe(value):
+    """Coerce a tool result into JSON-serializable form"""
+    return json.loads(json.dumps(value, default=repr))
 
 class SimpleToolOrchestrator(TextMessageHandlerProtocol):
     """
@@ -91,7 +97,10 @@ class SimpleToolOrchestrator(TextMessageHandlerProtocol):
             )
             
             llm_response = await self.llm.generate(conversation, options)
-            
+
+            if llm_response.usage:
+                await self.response.respond_event(UsageEvent(**llm_response.usage.model_dump()))
+
             # Add assistant response to conversation
             assistant_message = LLMMessage(
                 role=LLMRole.FUNCTION if llm_response.tool_calls else LLMRole.ASSISTANT,
@@ -111,32 +120,45 @@ class SimpleToolOrchestrator(TextMessageHandlerProtocol):
                 for tool_call in llm_response.tool_calls:
                     tool_name = tool_call.name
                     tool_args = tool_call.arguments
-                    
+
+                    await self.response.respond_event(ToolCallEvent(
+                        id=tool_call.id,
+                        name=tool_name,
+                        arguments=tool_args
+                    ))
+
                     try:
                         tool_result = await self.tool_provider.execute_tool(tool_name, tool_args)
-                        
-                        if tool_result.success:
-                            tool_results.append({
-                                "id": tool_call.id,
-                                "name": tool_name,
-                                "result": json.dumps(tool_result.result, default=repr)
-                            })
-                        else:
-                            # Tool execution failed
-                            tool_results.append({
-                                "id": tool_call.id,
-                                "name": tool_name,
-                                "error": f"Error: {tool_result.error}"
-                            })
-                            stress_level += 0.1
+                        success = tool_result.success
+                        result = tool_result.result if success else None
+                        error = tool_result.error if not success else None
                     except Exception as e:
                         # Handle any exceptions during tool execution
+                        success = False
+                        result = None
+                        error = str(e)
+
+                    if success:
                         tool_results.append({
                             "id": tool_call.id,
                             "name": tool_name,
-                            "error": f"Error: {str(e)}"
+                            "result": json.dumps(result, default=repr)
+                        })
+                    else:
+                        tool_results.append({
+                            "id": tool_call.id,
+                            "name": tool_name,
+                            "error": f"Error: {error}"
                         })
                         stress_level += 0.1
+
+                    await self.response.respond_event(ToolResultEvent(
+                        id=tool_call.id,
+                        name=tool_name,
+                        success=success,
+                        result=_json_safe(result),
+                        error=error
+                    ))
 
                 conversation.append(LLMMessage(
                     role=LLMRole.FUNCTION,                        

--- a/src/xaibo/primitives/modules/orchestrator/simple_tool_orchestrator.py
+++ b/src/xaibo/primitives/modules/orchestrator/simple_tool_orchestrator.py
@@ -4,6 +4,9 @@ from xaibo.core.models.llm import LLMMessage, LLMOptions, LLMRole, LLMFunctionRe
 from xaibo.core.models.response import ToolCallEvent, ToolResultEvent, UsageEvent
 
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _json_safe(value):
@@ -55,6 +58,14 @@ class SimpleToolOrchestrator(TextMessageHandlerProtocol):
         self.tool_provider: ToolProviderProtocol = tool_provider
         self.history = history
 
+    async def _emit_event(self, event) -> None:
+        """Send a response event if the response handler supports it."""
+        respond_event = getattr(self.response, "respond_event", None)
+        if respond_event is None:
+            logger.debug("Response handler does not implement respond_event; dropping %s event", event.type)
+            return
+        await respond_event(event)
+
     async def handle_text(self, text: str) -> None:
         """
         Process a user text message, potentially using tools to generate a response.
@@ -99,7 +110,7 @@ class SimpleToolOrchestrator(TextMessageHandlerProtocol):
             llm_response = await self.llm.generate(conversation, options)
 
             if llm_response.usage:
-                await self.response.respond_event(UsageEvent(**llm_response.usage.model_dump()))
+                await self._emit_event(UsageEvent(**llm_response.usage.model_dump()))
 
             # Add assistant response to conversation
             assistant_message = LLMMessage(
@@ -121,7 +132,7 @@ class SimpleToolOrchestrator(TextMessageHandlerProtocol):
                     tool_name = tool_call.name
                     tool_args = tool_call.arguments
 
-                    await self.response.respond_event(ToolCallEvent(
+                    await self._emit_event(ToolCallEvent(
                         id=tool_call.id,
                         name=tool_name,
                         arguments=tool_args
@@ -152,7 +163,7 @@ class SimpleToolOrchestrator(TextMessageHandlerProtocol):
                         })
                         stress_level += 0.1
 
-                    await self.response.respond_event(ToolResultEvent(
+                    await self._emit_event(ToolResultEvent(
                         id=tool_call.id,
                         name=tool_name,
                         success=success,

--- a/src/xaibo/primitives/modules/response.py
+++ b/src/xaibo/primitives/modules/response.py
@@ -1,7 +1,7 @@
 from typing import BinaryIO
 
 from xaibo.core.protocols import ResponseProtocol
-from xaibo.core.models import FileAttachment, FileType, Response
+from xaibo.core.models import FileAttachment, FileType, Response, ResponseEvent
 
 
 class ResponseHandler(ResponseProtocol):
@@ -9,7 +9,14 @@ class ResponseHandler(ResponseProtocol):
         self._response = Response()
 
     async def get_response(self) -> Response:
-        return self._response
+        # Events are turn-scoped: hand them off and reset
+        response = Response(
+            text=self._response.text,
+            attachments=self._response.attachments,
+            events=self._response.events
+        )
+        self._response.events = []
+        return response
 
     async def respond_text(self, response: str) -> None:
         if self._response.text is None:
@@ -33,3 +40,7 @@ class ResponseHandler(ResponseProtocol):
             else:
                 self._response.text += response.text
         self._response.attachments.extend(response.attachments)
+        self._response.events.extend(response.events)
+
+    async def respond_event(self, event: ResponseEvent) -> None:
+        self._response.events.append(event)

--- a/src/xaibo/server/adapters/openai.py
+++ b/src/xaibo/server/adapters/openai.py
@@ -127,6 +127,10 @@ class OpenAiApiAdapter:
                     response = create_chunk_response({"content": text})
                     await queue.put(f"data: {json.dumps(response)}\n\n")
 
+                async def respond_event(self, event) -> None:
+                    # The OpenAI chat completion grammar has no lane for agent internals
+                    pass
+
                 async def get_response(self):
                     return None
 

--- a/src/xaibo/server/adapters/openai_responses.py
+++ b/src/xaibo/server/adapters/openai_responses.py
@@ -412,6 +412,10 @@ class OpenAiResponsesApiAdapter:
                     await queue.put(f"data: {json.dumps(event_data)}\n\n")
                     self.accumulated_text += text
 
+                async def respond_event(self, event) -> None:
+                    # Agent internals are not part of the responses API surface yet
+                    pass
+
                 async def get_response(self):
                     return None
 

--- a/tests/agents/test_response_events.py
+++ b/tests/agents/test_response_events.py
@@ -1,0 +1,172 @@
+import pytest
+
+from xaibo import AgentConfig, Xaibo, ConfigOverrides, ExchangeConfig
+from xaibo.core.config import ModuleConfig
+from xaibo.core.models.response import (
+    Response,
+    ToolCallEvent,
+    ToolResultEvent,
+    UsageEvent,
+)
+from xaibo.core.models.tools import Tool, ToolResult
+from xaibo.primitives.modules.conversation import SimpleConversation
+from xaibo.primitives.modules.response import ResponseHandler
+
+
+class StubToolProvider:
+    def __init__(self, result: ToolResult):
+        self.result = result
+        self.calls = []
+
+    async def list_tools(self):
+        return [Tool(name="get_time", description="Gets the current time")]
+
+    async def execute_tool(self, tool_name, parameters):
+        self.calls.append((tool_name, parameters))
+        return self.result
+
+
+def make_agent(tool_provider, responses):
+    config = AgentConfig(
+        id="event-emitter",
+        modules=[
+            ModuleConfig(
+                module="xaibo.primitives.modules.llm.MockLLM",
+                id="llm",
+                config={"responses": responses},
+            ),
+            ModuleConfig(
+                module="xaibo.primitives.modules.orchestrator.SimpleToolOrchestrator",
+                id="orchestrator",
+                config={"max_thoughts": 5},
+            ),
+        ],
+    )
+    xaibo = Xaibo()
+    xaibo.register_agent(config)
+    return xaibo.get_agent_with("event-emitter", ConfigOverrides(
+        instances={
+            "tools": tool_provider,
+            "history": SimpleConversation(),
+        },
+        exchange=[
+            ExchangeConfig(protocol="ToolProviderProtocol", provider="tools"),
+            ExchangeConfig(protocol="ConversationHistoryProtocol", provider="history"),
+        ],
+    ))
+
+
+TOOL_CALL_RESPONSE = {
+    "content": "",
+    "tool_calls": [{"id": "call_1", "name": "get_time", "arguments": {"timezone": "UTC"}}],
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+}
+FINAL_RESPONSE = {
+    "content": "It is noon.",
+    "usage": {"prompt_tokens": 20, "completion_tokens": 4, "total_tokens": 24},
+}
+
+
+@pytest.mark.asyncio
+async def test_response_handler_accumulates_events():
+    handler = ResponseHandler()
+
+    await handler.respond_event(ToolCallEvent(id="call_1", name="get_time", arguments={}))
+    await handler.respond_event(ToolResultEvent(id="call_1", name="get_time", success=True, result="12:00"))
+    await handler.respond_text("It is noon.")
+
+    response = await handler.get_response()
+    assert response.text == "It is noon."
+    assert [e.type for e in response.events] == ["tool_call", "tool_result"]
+
+
+@pytest.mark.asyncio
+async def test_response_handler_merges_events_from_respond():
+    handler = ResponseHandler()
+
+    await handler.respond(Response(text="done", events=[UsageEvent(prompt_tokens=1, completion_tokens=2, total_tokens=3)]))
+
+    response = await handler.get_response()
+    assert [e.type for e in response.events] == ["usage"]
+
+
+@pytest.mark.asyncio
+async def test_response_handler_does_not_replay_events_across_turns():
+    handler = ResponseHandler()
+
+    await handler.respond_event(ToolCallEvent(id="call_1", name="get_time", arguments={}))
+    first = await handler.get_response()
+    assert [e.type for e in first.events] == ["tool_call"]
+
+    await handler.respond_event(UsageEvent(prompt_tokens=1, completion_tokens=2, total_tokens=3))
+    second = await handler.get_response()
+    # Only the second turn's events, and the first turn's response is untouched
+    assert [e.type for e in second.events] == ["usage"]
+    assert [e.type for e in first.events] == ["tool_call"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_emits_tool_and_usage_events():
+    tools = StubToolProvider(ToolResult(success=True, result="12:00"))
+    agent = make_agent(tools, [TOOL_CALL_RESPONSE, FINAL_RESPONSE])
+
+    response = await agent.handle_text("What time is it?")
+
+    assert response.text == "It is noon."
+    assert [e.type for e in response.events] == ["usage", "tool_call", "tool_result", "usage"]
+
+    tool_call = response.events[1]
+    assert tool_call.id == "call_1"
+    assert tool_call.name == "get_time"
+    assert tool_call.arguments == {"timezone": "UTC"}
+
+    tool_result = response.events[2]
+    assert tool_result.id == "call_1"
+    assert tool_result.success is True
+    assert tool_result.result == "12:00"
+
+    assert response.events[0].total_tokens == 15
+    assert response.events[3].total_tokens == 24
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_emits_failed_tool_result():
+    tools = StubToolProvider(ToolResult(success=False, error="tool unavailable"))
+    agent = make_agent(tools, [TOOL_CALL_RESPONSE, FINAL_RESPONSE])
+
+    response = await agent.handle_text("What time is it?")
+
+    tool_result = next(e for e in response.events if e.type == "tool_result")
+    assert tool_result.success is False
+    assert tool_result.error == "tool unavailable"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_emits_tool_result_on_exception():
+    class ExplodingToolProvider(StubToolProvider):
+        async def execute_tool(self, tool_name, parameters):
+            raise RuntimeError("kaboom")
+
+    tools = ExplodingToolProvider(None)
+    agent = make_agent(tools, [TOOL_CALL_RESPONSE, FINAL_RESPONSE])
+
+    response = await agent.handle_text("What time is it?")
+
+    tool_result = next(e for e in response.events if e.type == "tool_result")
+    assert tool_result.success is False
+    assert "kaboom" in tool_result.error
+
+
+@pytest.mark.asyncio
+async def test_tool_result_event_is_json_serializable():
+    from datetime import datetime
+
+    tools = StubToolProvider(ToolResult(success=True, result={"at": datetime(2026, 7, 16, 12, 0)}))
+    agent = make_agent(tools, [TOOL_CALL_RESPONSE, FINAL_RESPONSE])
+
+    response = await agent.handle_text("What time is it?")
+
+    tool_result = next(e for e in response.events if e.type == "tool_result")
+    # Non-JSON-serializable values are coerced (via repr), so events can go on the wire
+    tool_result.model_dump_json()
+    assert "2026" in tool_result.result["at"]

--- a/tests/agents/test_response_events.py
+++ b/tests/agents/test_response_events.py
@@ -158,6 +158,55 @@ async def test_orchestrator_emits_tool_result_on_exception():
 
 
 @pytest.mark.asyncio
+async def test_legacy_response_handler_without_respond_event_still_works():
+    """A handler that predates respond_event is skipped, not crashed (events are an optional capability)."""
+    class LegacyResponseHandler:
+        def __init__(self):
+            self._text = None
+
+        async def respond_text(self, text):
+            self._text = text
+
+        async def get_response(self):
+            return Response(text=self._text)
+
+    tools = StubToolProvider(ToolResult(success=True, result="12:00"))
+    config = AgentConfig(
+        id="event-emitter",
+        modules=[
+            ModuleConfig(
+                module="xaibo.primitives.modules.llm.MockLLM",
+                id="llm",
+                config={"responses": [TOOL_CALL_RESPONSE, FINAL_RESPONSE]},
+            ),
+            ModuleConfig(
+                module="xaibo.primitives.modules.orchestrator.SimpleToolOrchestrator",
+                id="orchestrator",
+                config={"max_thoughts": 5},
+            ),
+        ],
+    )
+    xaibo = Xaibo()
+    xaibo.register_agent(config)
+    agent = xaibo.get_agent_with("event-emitter", ConfigOverrides(
+        instances={
+            "tools": tools,
+            "history": SimpleConversation(),
+            "__response__": LegacyResponseHandler(),
+        },
+        exchange=[
+            ExchangeConfig(protocol="ToolProviderProtocol", provider="tools"),
+            ExchangeConfig(protocol="ConversationHistoryProtocol", provider="history"),
+        ],
+    ))
+
+    response = await agent.handle_text("What time is it?")
+
+    assert response.text == "It is noon."
+    assert len(tools.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_tool_result_event_is_json_serializable():
     from datetime import datetime
 


### PR DESCRIPTION
Step 2 of the AG-UI plan discussed (#38 is step 1). The goal is an `AGUIAdapter` that renders any xaibo agent in any AG-UI frontend with tool calls, steps, and reasoning visible. For that, adapters need something richer than final text to translate. The current `ResponseProtocol` carries text and file attachments only — everything else an agent does is invisible at the response seam.

Per the discussion, this extends the **existing** `ResponseProtocol`/`Response` rather than introducing a parallel streaming protocol.

## If I Got It Correctly...

In practice, xaibo users write their own orchestrator modules. The ones we have now are starting templates, eg the SimpleOrchestrator and ReActOrchestrator. `ResponseProtocol` is the one channel every orchestrator, shipped or custom, has to the frontend, and today it only carries text. So any orchestrator that wants to surface its internals has to invent an ad-hoc encoding inside the response text. The `ReActOrchestrator` template demonstrates exactly this workaround (`🛠️ **EXECUTING TOOL:** ...` emoji prose), and every downstream project would have to rebuild some variant of it, each unparseable by any standard frontend.

This PR gives the seam a typed vocabulary instead, so custom orchestrators emit structured events once and every adapter can translate them uniformly.

## Changes

- **`core/models/response.py`** - a typed event union. The semantics are aligned with AG-UI's taxonomy so the future adapter mapping stays thin, but the classes are xaibo's own rather than imports from the `ag-ui-protocol` SDK. Since the AG-UI is pre-1.0 and its spec still changes, keeping its types out of the core makes sense. Any future spec changes only needs to touch the adapter. 
  - `ToolCallEvent(id, name, arguments)` / `ToolResultEvent(id, name, success, result?, error?)`
  - `UsageEvent` - subclasses the existing `LLMUsage`, so future usage fields (cached tokens, reasoning tokens) flow through without touching this model.
  - `Response` gains an `events: List[ResponseEvent]` field.
  - Only event types the reference implementation actually produces are included; reasoning/step events land when a template that emits them does.
- **`core/protocols/response.py`** - one new method: `respond_event(event)`. Single entry point, so adding event types later doesn't grow the protocol surface a custom orchestrator programs against.
- **`primitives/modules/response.py`** - `ResponseHandler` accumulates events into the `Response`; `respond(...)` merges them. Events are turn-scoped: `get_response()` hands them off and resets, so a reused agent instance doesn't replay the previous turn's usage/tool events (text/attachment accumulation semantics are unchanged).
- **`orchestrator/simple_tool_orchestrator.py`** - updated as the reference for how an orchestrator uses the new surface: `UsageEvent` after each LLM call, `ToolCallEvent` before each tool execution, `ToolResultEvent` after (success, failure, and exception paths converge on a single emission site). This is the template users copy when writing their own orchestrators, and it doubles as the real producer the API is tested against. Tool results in the event are coerced with a `json.dumps(..., default=repr)` round-trip - the same treatment tool results already get on the conversation path in both orchestrator templates and that event payloads get in the debug trace listener (`ui.py`), so a raw copy here would be the inconsistency.
- **Adapters** (`openai.py`, `openai_responses.py`, livekit `llm.py`) - their inline response handlers implement `respond_event` as a no-op: they acknowledge events but don't forward them, since their wire formats have no lane for agent internals. Because the call still happens, it crosses the observability proxy - tool calls and usage stay visible in the debug trace when serving through these adapters. The AG-UI adapter will be the first consumer that actually forwards them.

## Other technical details

- **Whole-event granularity only - no deltas.** Deliberate: `respond_event` calls go through the observability proxy like every module call, so delta-shaped methods would put per-token events into the event log (the log-volume concern). Whole events are one log entry per meaningful action. Token-level text deltas are a separate, later decision (needs the delta-aware event listener discussed in the standup).
- Events are pydantic models with a `type` discriminator. Serializable for free, both in the event log and for future SSE adapters.
- A side benefit of routing through the proxy: every `respond_event` call lands in the observability log with full envelope, so the debug UI sees tool calls and usage per agent run without any listener changes, for custom orchestrators too, automatically.
- The `ReActOrchestrator` template is intentionally left as-is: its emoji-prose output is user-visible behavior that people may have copied, and converting it to events could be updated in another PR once this shape is agreed.

## Compatibility

- Agent YAMLs: no change. `Response`/`ResponseHandler` changes are additive.
- User-written orchestrators: unaffected until they opt in - nothing requires emitting events.
- **Existing `ResponseProtocol` implementations: unaffected.** Events are an optional capability (see below) — a handler that predates `respond_event` keeps working unchanged; it just doesn't receive events.

--- 

## Update 1: Events are an optional capability (per the discussion)

Response handlers in xaibo support what they support - partial implementations are the norm (the adapters' inline handlers implement only `respond_text` + `get_response`, and nothing forces more). Per the discussion, `respond_event` should follow the same rule rather than becoming a hard requirement: the orchestrator template emits through a small guard (`_emit_event`) that checks the handler for `respond_event` and skips if absent. A handler that wants events extends to support them.

One behavior note: a *skipped* emission never crosses the observability proxy, so it can't appear in the debug event trace - the guard logs a `logger.debug` line instead so dropped events stay diagnosable. Handlers that implement `respond_event`, even as a no-op like the in-repo adapters, keep full trace visibility since the call happens and is recorded before being ignored.

A shared default base class (implementers get no-op event handling without writing it) is a natural follow-up once the AG-UI adapter exists as the first real event consumer to design it against.

## Verification

```bash
uv run pytest tests/agents/test_response_events.py -v   # 8 new tests
uv run pytest --continue-on-collection-errors -q        # 145 passed, 18 skipped
```

New tests cover: `ResponseHandler` accumulation, merge, and per-turn event reset; a full agent run (MockLLM + stub tool provider through the real Exchange) asserting the event sequence `[usage, tool_call, tool_result, usage]` with payloads; failed-tool and exception paths; JSON-serializability of events carrying non-serializable tool results (datetime); a legacy response handler without `respond_event` running uncrashed through the event-emitting orchestrator.
