### PR TITLE
Deploy documentation with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,47 +2,71 @@ name: Website Documentation
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
+  pull_request:
     paths:
-      - 'docs/**'
-      - mkdocs.yml
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: 'placeholder'
+      - name: Check out repository
+        uses: actions/checkout@v7
 
-      - name: Adding Known Hosts
-        run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
-      
+          python-version: "3.11"
+
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10
         with:
-          version: latest
-      
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+          version: latest-known
+
+      - name: Install documentation dependencies
+        run: uv sync --frozen --no-install-project
+
+      - name: Build documentation
+        run: uv run --no-sync mkdocs build --strict
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          version: latest
-      
-      - name: Install dependencies
-        run: |
-          # Install all dependency groups needed for tests
-          uv sync --all-extras --all-groups
-      
-      - name: Build Docs
-        run: |
-          uv run mkdocs build --strict
-      - name: Copying to www.xaibo.ai
-        run: rsync -a -v -h site/ ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/var/www/xaibo.ai/ --delete
+          path: site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: latest-known
 


### PR DESCRIPTION
## Summary

- replace the SSH/rsync documentation deployment with GitHub Pages
- build and upload the existing MkDocs `site/` output without changing documentation content or `mkdocs.yml`
- validate documentation builds on pull requests while deploying only pushes to `main`
- scope `pages: write` and `id-token: write` permissions to the deployment job
- use the checked-in `uv.lock` and skip installing/building the Xaibo package and UI, which the docs build does not require

## Why

The previous workflow copied the generated site to a self-managed server over SSH. That server was compromised, so the documentation should no longer depend on a persistent host or SSH deployment credentials.

GitHub Pages can host the same static MkDocs output at the existing `xaibo.ai` apex domain.

## Impact

Documentation sources and site configuration are unchanged. Once the one-time repository and DNS setup below is complete, merges affecting docs or their dependencies will publish automatically through GitHub Pages.

## Validation

- `actionlint .github/workflows/docs.yml`
- clean Python 3.11 container:
  - `uv sync --frozen --no-install-project`
  - `uv run --no-sync mkdocs build --strict`
- build completed successfully with 212 generated files (14 MB)

The build retains one existing informational message: `tutorial/advanced-orchestration.md` links to an anchor that is not present in `how-to/index.md`. It does not fail strict mode and is unrelated to this deployment change.

## One-time cutover after merge

1. In **Settings → Pages**, select **GitHub Actions** as the publishing source.
2. Verify `xaibo.ai` for the XpressAI organization, then set it as this repository's Pages custom domain.
3. Replace the current apex DNS record with GitHub Pages' four A records:
   - `185.199.108.153`
   - `185.199.109.153`
   - `185.199.110.153`
   - `185.199.111.153`
4. Point `www` via CNAME to `xpressai.github.io`.
5. Enable **Enforce HTTPS** once GitHub provisions the certificate.
6. Remove the obsolete SSH deployment secrets and revoke the old deployment key after cutover.
